### PR TITLE
Fix reset max connections reached after a accept new connections from…

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -33,6 +33,10 @@ function RateLimit(options) {
             }
         }, options.windowMs);
 
+        if(!hits[ip]) {
+            hits[ip] = 0;
+        }
+
         if (hits[ip] >= options.max) {
             // 429 status = Too Many Requests (RFC 6585)
             return res.status(429).end(options.message);


### PR DESCRIPTION
… blocked IP.

Issue: after an reset of a blocked IP all connections still open, because hits[ip] === NaN.
Fix: Reset hits[ip] to a Number
