### PR TITLE
FIX: Initialize counter to 1

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -28,7 +28,7 @@ function RateLimit(options) {
         setTimeout(function() {
             // cleanup
             hits[ip]--;
-            if (hits[ip] <=0 ) {
+            if (hits[ip] < 0 ) {
                 delete hits[ip];
             }
         }, options.windowMs);

--- a/test/test.js
+++ b/test/test.js
@@ -168,4 +168,25 @@ describe('express-rate-limit node module', function() {
             });
         }, 60);
     });
+
+    it("should block requests a second time after (eventually) accepting them from a blocked IP ", function(done) {
+        createAppWith(rateLimit({
+            delayMs: 100,
+            max: 1,
+            windowMs: 50
+        }));
+        goodRequest(done);
+        badRequest(done);
+        setTimeout(function() {
+            start = Date.now();
+            goodRequest(done);
+            badRequest(done, function( /* err, res */ ) {
+                if (delay > 150) {
+                    done(new Error("Second request took too long: " + delay + "ms"));
+                } else {
+                    done();
+                }
+            });
+        }, 60);
+    });
 });


### PR DESCRIPTION
If the counter is initialized to zero, the decrement function is called one too many times.  It resets hits[ip] to undefined when it reaches zero, but then it decrements again, which sets hits[ip] = NaN (`undefined--` evaluates to `NaN`.  `typeof NaN === 'number'`, so this error is never corrected, and the limiter fails to work correctly for all future requests.