### PR TITLE
Add a handler option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - stable
+  - 4.2
   - '0.12'
 sudo: false

--- a/README.md
+++ b/README.md
@@ -25,8 +25,27 @@ $ npm install --save express-rate-limit
 * **max**: max number of connections during `windowMs` milliseconds before sending a 429 response. Defaults to `5`. Set to `0` to disable.
 * **message**: Error message returned when `max` is exceeded. Defaults to `'Too many requests, please try again later.'`
 * **statusCode**: HTTP status code returned when `max` is exceeded. Defaults to `429`.
+* **handler**: The function to execute once the max limit is exceeded. It receives the response object. Defaults:
+```js
+function (res) {
+  res.format({
+    'text/plain': function(){
+      res.status(options.statusCode).send(options.message);
+    },
+    'text/html': function(){
+      res.status(options.statusCode).send('<p>' + options.message + '</p>');
+    },
+    'application/json': function(){
+      res.status(options.statusCode).json({ message: options.message });
+    },
+    'default': function() {
+      res.status(options.statusCode).send(options.message);
+    }
+  });
+}
+```
 
-The `delayAfter` and `delayMs` options were written for human-facing pages such as login and password reset forms. 
+The `delayAfter` and `delayMs` options were written for human-facing pages such as login and password reset forms.
 For public APIs, setting these to `0` (disabled) and relying on only `windowMs` and `max` for rate-limiting usually makes the most sense.
 
 ## Usage
@@ -68,7 +87,7 @@ app.post('/reset-rate-limit', limiter2, function(req, res) {
    // validate that requester has filled out a captcha properly or whatever and then...
   limiter.resetIp(req.ip);
   // ...
-} 
+}
 ```
 
 ## Instance API

--- a/README.md
+++ b/README.md
@@ -25,21 +25,15 @@ $ npm install --save express-rate-limit
 * **max**: max number of connections during `windowMs` milliseconds before sending a 429 response. Defaults to `5`. Set to `0` to disable.
 * **message**: Error message returned when `max` is exceeded. Defaults to `'Too many requests, please try again later.'`
 * **statusCode**: HTTP status code returned when `max` is exceeded. Defaults to `429`.
-* **handler**: The function to execute once the max limit is exceeded. It receives the response object. Defaults:
+* **handler**: The function to execute once the max limit is exceeded. It receives the request and the response objects. The "next" param is available if you need to pass to the next middleware. Defaults:
 ```js
-function (res) {
+function (req, res, /*next*/) {
   res.format({
-    'text/plain': function(){
-      res.status(options.statusCode).send(options.message);
+    html: function(){
+      res.status(options.statusCode).end(options.message);
     },
-    'text/html': function(){
-      res.status(options.statusCode).send('<p>' + options.message + '</p>');
-    },
-    'application/json': function(){
+    json: function(){
       res.status(options.statusCode).json({ message: options.message });
-    },
-    'default': function() {
-      res.status(options.statusCode).send(options.message);
     }
   });
 }

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -10,7 +10,23 @@ function RateLimit(options) {
         delayMs: 1000, // milliseconds - base delay applied to the response - multiplied by number of recent hits from user's IP
         max: 5, // max number of recent connections during `window` miliseconds before sending a 429 response
         message : 'Too many requests, please try again later.',
-        statusCode: 429 // 429 status = Too Many Requests (RFC 6585)
+        statusCode: 429, // 429 status = Too Many Requests (RFC 6585)
+        handler: function (res) {
+          res.format({
+            'text/plain': function(){
+              res.status(options.statusCode).send(options.message);
+            },
+            'text/html': function(){
+              res.status(options.statusCode).send('<p>' + options.message + '</p>');
+            },
+            'application/json': function(){
+              res.status(options.statusCode).json({ message: options.message });
+            },
+            'default': function() {
+              res.status(options.statusCode).send(options.message);
+            }
+          });
+        }
     });
 
 
@@ -33,7 +49,7 @@ function RateLimit(options) {
         }
 
         if (options.max && hits[ip] > options.max) {
-            return res.status(options.statusCode).end(options.message);
+            return options.handler(res);
         }
 
         if (options.delayAfter && options.delayMs && hits[ip] > options.delayAfter) {

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -11,19 +11,13 @@ function RateLimit(options) {
         max: 5, // max number of recent connections during `window` miliseconds before sending a 429 response
         message : 'Too many requests, please try again later.',
         statusCode: 429, // 429 status = Too Many Requests (RFC 6585)
-        handler: function (res) {
+        handler: function (req, res /*, next*/) {
           res.format({
-            'text/plain': function(){
-              res.status(options.statusCode).send(options.message);
+            html: function(){
+              res.status(options.statusCode).end(options.message);
             },
-            'text/html': function(){
-              res.status(options.statusCode).send('<p>' + options.message + '</p>');
-            },
-            'application/json': function(){
+            json: function(){
               res.status(options.statusCode).json({ message: options.message });
-            },
-            'default': function() {
-              res.status(options.statusCode).send(options.message);
             }
           });
         }
@@ -49,7 +43,7 @@ function RateLimit(options) {
         }
 
         if (options.max && hits[ip] > options.max) {
-            return options.handler(res);
+            return options.handler(req,res, next);
         }
 
         if (options.delayAfter && options.delayMs && hits[ip] > options.delayAfter) {

--- a/package.json
+++ b/package.json
@@ -25,19 +25,20 @@
     "security"
   ],
   "dependencies": {
-    "defaults": "^1.0.2"
+    "defaults": "^1.0.3"
   },
   "devDependencies": {
     "express": "^4.13.3",
+    "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
-    "grunt-contrib-jshint": "^0.11.3",
+    "grunt-contrib-jshint": "^0.12.0",
     "grunt-contrib-nodeunit": "^0.4.1",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-mocha-cli": "^1.14.0",
-    "jshint-stylish": "^2.0.1",
-    "load-grunt-tasks": "^3.3.0",
+    "grunt-mocha-cli": "^2.0.0",
+    "jshint-stylish": "^2.1.0",
+    "load-grunt-tasks": "^3.4.0",
     "supertest": "^1.1.0",
-    "time-grunt": "^1.2.1"
+    "time-grunt": "^1.3.0"
   },
   "scripts": {
     "test": "grunt"


### PR DESCRIPTION
The handler defaults to a function which receives a response object of Express
and negociates the content of the response based on the Contetn-Type header of the request.

Files changed:
modified:   README.md
modified:   lib/express-rate-limit.js