### PR TITLE
customize how IP is obtained from req object

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -11,6 +11,9 @@ function RateLimit(options) {
         max: 5, // max number of recent connections during `window` miliseconds before sending a 429 response
         message : 'Too many requests, please try again later.',
         statusCode: 429, // 429 status = Too Many Requests (RFC 6585)
+        ipRetrieveFn: function (req) {
+          return req.ip;
+        },
         handler: function (req, res /*, next*/) {
           res.format({
             html: function(){
@@ -34,7 +37,7 @@ function RateLimit(options) {
 
 
     function rateLimit(req, res, next) {
-        var ip = req.ip;
+        var ip = options.ipRetrieveFn(req);
 
         if (hits[ip]) {
             hits[ip]++;


### PR DESCRIPTION
`req.ip` does not reliably represent client's IP address in load-balanced environments like Google App Engine and Heroku. This change allows users to define how to retrieve IP address from a request object, so they could use a custom header field if needed.