### PR TITLE
The ability to use a custom source if IP to be used as key

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ app.post('/create-account', createAccountLimiter, function(req, res) {
 * **delayMs**: milliseconds - how long to delay the response, multiplied by (number of recent hits - `delayAfter`).  Defaults to `1000` (1 second). Set to `0` to disable delaying.
 * **max**: max number of connections during `windowMs` milliseconds before sending a 429 response. Defaults to `5`. Set to `0` to disable.
 * **message**: Error message returned when `max` is exceeded. Defaults to `'Too many requests, please try again later.'`
+* **realIpHeader**: string - name of an HTTP header to extract real user ip from
+* **realIpParam** string - name of request child member (example: req.realIpHeader) to extract the real user ip from
 * **statusCode**: HTTP status code returned when `max` is exceeded. Defaults to `429`.
 * **keyGenerator**: Function used to generate keys. By default user IP address (req.ip) is used. Defaults:
 ```js

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -11,8 +11,18 @@ function RateLimit(options) {
         max: 5, // max number of recent connections during `window` milliseconds before sending a 429 response
         message : 'Too many requests, please try again later.',
         statusCode: 429, // 429 status = Too Many Requests (RFC 6585)
+        realIpHeader: '', // custom user defined header to extract real ip from
+        realIpParam: '', // custom user defined request child member to extract real ip from
         // allows to create custom keys (by default user IP is used)
         keyGenerator: function (req /*, res*/) {
+            if (!!options.realIpHeader) {
+              return req.get(options.realIpHeader);
+            }
+
+            if (!!options.realIpParam) {
+              return req[options.realIpParam];
+            }
+
             return req.ip;
         },
         handler: function (req, res /*, next*/) {


### PR DESCRIPTION
the problem to solve is that in cases where a proxy or load balancer is on top of the express application, req.ip might be populated with the lb/proxy ip. and then the limiter will block every user.

this way you can define the source of the IP, a custom header or request param, where it will usually be populated in.