### PR TITLE
Abstracted backend store out from RateLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ var SomeStore = function() {
     };
 
     /**
-     * This callback is called buy the underlying store when an answer to the
+     * This callback is called by the underlying store when an answer to the
      * increment is available.
      * @callback Store~incrCallback
      * @param {?object} err - The error from the underlying store, or null if no

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Basic rate-limiting middleware for Express. Use to limit repeated requests to public APIs and/or endpoints such as password reset.
 
-Note: this module does not share state with other processes/servers.
+Note: this module does not share state with other processes/servers by default.
 If you need a more robust solution, I recommend checking out [strict-rate-limiter](https://www.npmjs.com/package/strict-rate-limiter) or [express-brute](https://www.npmjs.com/package/express-brute), both are excellent pieces of software.
 
 
@@ -106,6 +106,40 @@ function (req, res, /*next*/) {
     }
   });
 }
+```
+* **store**: The storage to use when persisting rate limit attempts. By default, the [MemoryStore](lib/memory-store.js) is used. It must implement the following in order to function:
+```js
+var SomeStore = function() {
+    /**
+      * Increments the value in the underlying store for the given key.
+      * @method function
+      * @param {string} key - The key to use as the unique identifier passed
+      *                     down from RateLimit.
+      * @param {Store~incrCallback} cb - The callback issued when the underlying
+      *                                store is finished.
+      */
+    this.incr = function(key, cb) {
+      // ...
+    };
+
+    /**
+     * This callback is called buy the underlying store when an answer to the
+     * increment is available.
+     * @callback Store~incrCallback
+     * @param {?object} err - The error from the underlying store, or null if no
+     *                      error occurred.
+     * @param {number} value - The current value of the counter
+     */
+
+    /**
+     * Resets a value with the given key.
+     * @method function
+     * @param  {[type]} key - The key to reset
+     */
+    this.resetKey = function(key) {
+      // ...
+    };
+};
 ```
 
 The `delayAfter` and `delayMs` options were written for human-facing pages such as login and password reset forms.

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -84,10 +84,10 @@ function RateLimit(options) {
         });
     }
 
-    rateLimit.resetKey = options.store.resetKey.bind(options.store);;
+    rateLimit.resetKey = options.store.resetKey.bind(options.store);
 
     // Backward compatibility function
-    rateLimit.resetIp = options.store.resetKey.bind(options.store);;
+    rateLimit.resetIp = options.store.resetKey.bind(options.store);
 
     return rateLimit;
 }

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -1,31 +1,6 @@
 'use strict';
 var defaults = require('defaults');
-
-var MemoryStore = function(windowMs) {
-  var hits = {};
-
-  this.incr = function(key, cb) {
-    if (hits[key]) {
-        hits[key]++;
-    } else {
-        hits[key] = 1;
-    }
-
-    cb(null, hits[key]);
-  };
-
-  this.resetAll = function() {
-    hits = {};
-  };
-
-  // export an API to allow hits from one or all IPs to be reset
-  this.resetKey = function(key) {
-      delete hits[key];
-  };
-
-  // simply reset ALL hits every windowMs
-  setInterval(this.resetAll, windowMs);
-};
+var MemoryStore = require('./memory-store');
 
 function RateLimit(options) {
 
@@ -53,9 +28,15 @@ function RateLimit(options) {
         }
     });
 
-    options = defaults(options, {
-      store: new MemoryStore(options.windowMs), // store to use for persisting rate limit data
-    });
+
+    // store to use for persisting rate limit data
+    options.store = options.store || new MemoryStore(options.windowMs);
+
+
+    // ensure that the store has the incr method
+    if (typeof options.store.incr !== 'function' || typeof options.store.resetKey !== 'function') {
+        throw new Error('The store is not valid.');
+    }
 
 
     if (options.global) {

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -1,11 +1,37 @@
 'use strict';
 var defaults = require('defaults');
 
+var MemoryStore = function(windowMs) {
+  var hits = {};
+
+  this.incr = function(key, cb) {
+    if (hits[key]) {
+        hits[key]++;
+    } else {
+        hits[key] = 1;
+    }
+
+    cb(null, hits[key]);
+  };
+
+  this.resetAll = function() {
+    hits = {};
+  };
+
+  // export an API to allow hits from one or all IPs to be reset
+  this.resetKey = function(key) {
+      delete hits[key];
+  };
+
+  // simply reset ALL hits every windowMs
+  setInterval(this.resetAll, windowMs);
+};
+
 function RateLimit(options) {
 
     options = defaults(options, {
         // window, delay, and max apply per-key unless global is set to true
-        windowMs: 60 * 1000, // milliseconds - how long to keep records of requests in memory
+        windowMs: 60 * 1000, // milliseconds - how long to keep records of requests in memory: Only used when store is MemoryStore
         delayAfter: 1, // how many requests to allow through before starting to delay responses
         delayMs: 1000, // milliseconds - base delay applied to the response - multiplied by number of recent hits for the same key.
         max: 5, // max number of recent connections during `window` milliseconds before sending a 429 response
@@ -27,52 +53,41 @@ function RateLimit(options) {
         }
     });
 
+    options = defaults(options, {
+      store: new MemoryStore(options.windowMs), // store to use for persisting rate limit data
+    });
+
 
     if (options.global) {
         throw new Error('The global option was removed from express-rate-limit v2.');
     }
 
 
-    // this is shared by all endpoints that use this instance
-    var hits = {};
-
-
     function rateLimit(req, res, next) {
         var key = options.keyGenerator(req, res);
 
-        if (hits[key]) {
-            hits[key]++;
-        } else {
-            hits[key] = 1;
-        }
+        options.store.incr(key, function(err, current) {
+          if (err) {
+            return next(err);
+          }
 
-        if (options.max && hits[key] > options.max) {
-            return options.handler(req,res, next);
-        }
+          if (options.max && current > options.max) {
+              return options.handler(req,res, next);
+          }
 
-        if (options.delayAfter && options.delayMs && hits[key] > options.delayAfter) {
-            var delay = (hits[key] - options.delayAfter) * options.delayMs;
-            setTimeout(next, delay);
-        } else {
-            next();
-        }
+          if (options.delayAfter && options.delayMs && current > options.delayAfter) {
+              var delay = (current - options.delayAfter) * options.delayMs;
+              setTimeout(next, delay);
+          } else {
+              next();
+          }
+        });
     }
 
-    function resetAll() {
-        hits = {};
-    }
+    rateLimit.resetKey = options.store.resetKey;
 
-    // simply reset ALL hits every windowMs
-    setInterval(resetAll, options.windowMs);
-
-    // export an API to allow hits from one or all IPs to be reset
-    function resetKey(key) {
-        delete hits[key];
-    }
-
-    rateLimit.resetKey = resetKey;
     // Backward compatibility function
-    rateLimit.resetIp = resetKey;
+    rateLimit.resetIp = options.store.resetKey;
 
     return rateLimit;
 }

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -84,10 +84,10 @@ function RateLimit(options) {
         });
     }
 
-    rateLimit.resetKey = options.store.resetKey;
+    rateLimit.resetKey = options.store.resetKey.bind(options.store);;
 
     // Backward compatibility function
-    rateLimit.resetIp = options.store.resetKey;
+    rateLimit.resetIp = options.store.resetKey.bind(options.store);;
 
     return rateLimit;
 }

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -6,7 +6,7 @@ function RateLimit(options) {
 
     options = defaults(options, {
         // window, delay, and max apply per-key unless global is set to true
-        windowMs: 60 * 1000, // milliseconds - how long to keep records of requests in memory: Only used when store is MemoryStore
+        windowMs: 60 * 1000, // milliseconds - how long to keep records of requests in memory
         delayAfter: 1, // how many requests to allow through before starting to delay responses
         delayMs: 1000, // milliseconds - base delay applied to the response - multiplied by number of recent hits for the same key.
         max: 5, // max number of recent connections during `window` milliseconds before sending a 429 response

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -87,7 +87,7 @@ function RateLimit(options) {
     rateLimit.resetKey = options.store.resetKey.bind(options.store);
 
     // Backward compatibility function
-    rateLimit.resetIp = options.store.resetKey.bind(options.store);
+    rateLimit.resetIp = rateLimit.resetKey;
 
     return rateLimit;
 }

--- a/lib/memory-store.js
+++ b/lib/memory-store.js
@@ -1,0 +1,27 @@
+var MemoryStore = function(windowMs) {
+  var hits = {};
+
+  this.incr = function(key, cb) {
+      if (hits[key]) {
+          hits[key]++;
+      } else {
+          hits[key] = 1;
+      }
+
+      cb(null, hits[key]);
+  };
+
+  this.resetAll = function() {
+      hits = {};
+  };
+
+  // export an API to allow hits from one or all IPs to be reset
+  this.resetKey = function(key) {
+      delete hits[key];
+  };
+
+  // simply reset ALL hits every windowMs
+  setInterval(this.resetAll, windowMs);
+};
+
+module.exports = MemoryStore;

--- a/test/memory-store.js
+++ b/test/memory-store.js
@@ -1,0 +1,121 @@
+/*global describe, it */
+var MemoryStore = require('../lib/memory-store.js');
+
+describe('MemoryStore store', function() {
+  it("increments the key for the store each incr", function(done) {
+    var store = new MemoryStore(-1);
+    var key = "test-store";
+
+    store.incr(key, function(err, value) {
+        if (err) {
+            done(err);
+        } else {
+            if (value === 1) {
+                done();
+            } else {
+                done(new Error("incr did not set the key on the store to 1"));
+            }
+        }
+    });
+  });
+
+  it("increments the key for the store each incr", function(done) {
+    var store = new MemoryStore(-1);
+    var key = "test-store";
+
+    store.incr(key, function() {
+        store.incr(key, function(err, value) {
+            if (err) {
+                done(err);
+            } else {
+                if (value === 2) {
+                    done();
+                } else {
+                    done(new Error("incr did not increment the store"));
+                }
+            }
+        });
+    });
+  });
+
+  it("resets the key for the store when used with resetKey", function(done) {
+    var store = new MemoryStore(-1);
+    var key = "test-store";
+
+    store.incr(key, function() {
+        // value should be 1 now
+        store.resetKey(key);
+        // value should be 0 now
+        store.incr(key, function(err, value) {
+            // value should be 1 now
+            if (value === 1) {
+                done();
+            } else {
+                done(new Error("resetKey did not reset the store for the key provided"));
+            }
+        });
+    });
+  });
+
+  it("resets all keys for the store when used with resetAll", function(done) {
+    var store = new MemoryStore(-1);
+    var keyOne = "test-store-one";
+    var keyTwo = "test-store-two";
+
+    store.incr(keyOne, function() {
+      // valueOne should be 1 now
+      store.incr(keyTwo, function() {
+        // valueTwo should be 1 now
+        store.resetAll();
+        // valueOne should be 0 now
+        // valueTwo should be 0 now
+        store.incr(keyOne, function(err, valueOne) {
+          // valueOne should be 1 now
+          if (valueOne === 1) {
+              store.incr(keyTwo, function(err, valueTwo) {
+                // valueTwo should be 1 now
+                if (valueTwo === 1) {
+                  done();
+                } else {
+                  done(new Error("resetAll did not reset all the keys in the store"));
+                }
+              });
+          } else {
+              done(new Error("resetAll did not reset all the keys in the store"));
+          }
+        });
+      });
+    });
+  });
+
+  it("resets all keys for the store when the timeout is reached", function(done) {
+    var store = new MemoryStore(50);
+    var keyOne = "test-store-one";
+    var keyTwo = "test-store-two";
+
+    store.incr(keyOne, function() {
+      // valueOne should be 1 now
+      store.incr(keyTwo, function() {
+        // valueTwo should be 1 now
+        setTimeout(function() {
+          // valueOne and valueTwo should be 0 now
+          store.incr(keyOne, function(err, valueOne) {
+            // valueOne should be 1 now
+            if (valueOne === 1) {
+                store.incr(keyTwo, function(err, valueTwo) {
+                  // valueTwo should be 1 now
+                  if (valueTwo === 1) {
+                    done();
+                  } else {
+                    done(new Error("reaching the timeout did not reset all the keys in the store"));
+                  }
+                });
+            } else {
+                done(new Error("reaching the timeout did not reset all the keys in the store"));
+            }
+          });
+        }, 60);
+      });
+    });
+  });
+});

--- a/test/memory-store.js
+++ b/test/memory-store.js
@@ -2,7 +2,7 @@
 var MemoryStore = require('../lib/memory-store.js');
 
 describe('MemoryStore store', function() {
-  it("sets the value to 0 on first incr", function(done) {
+  it("sets the value to 1 on first incr", function(done) {
     var store = new MemoryStore(-1);
     var key = "test-store";
 

--- a/test/memory-store.js
+++ b/test/memory-store.js
@@ -2,7 +2,7 @@
 var MemoryStore = require('../lib/memory-store.js');
 
 describe('MemoryStore store', function() {
-  it("increments the key for the store each incr", function(done) {
+  it("sets the value to 0 on first incr", function(done) {
     var store = new MemoryStore(-1);
     var key = "test-store";
 


### PR DESCRIPTION
I really liked the simplicity of the package, but I wanted to extend it for use with other stores.

I've abstracted out the Memory Store into a model that can now be plugged in as need be with other databases. The only requirements of any other store is that it must provide the following methods:

- `incr`: This method must accept a key, and a callback, the key will be incremented and the new value returned in the callback, along with any error that occurred.
- `resetKey`: This method resets the key indicated in an atomic operation
- `resetAll` (optional): This method resets all the keys stored for the rate limiting middleware

Would love for any feedback :)