### PR TITLE
Passing the current rate limited value as part of handler

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -70,7 +70,7 @@ function RateLimit(options) {
             }
 
             if (options.max && current > options.max) {
-              return options.handler(req, res, next);
+              return options.handler(req, res, next, current);
             }
 
             if (options.delayAfter && options.delayMs && current > options.delayAfter) {


### PR DESCRIPTION
Passing rate limited value as part of handler will help to use it for other analysis such as max number of rate limit hit.