### PR TITLE
Passing current limit as part of rateLimit payload

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -61,6 +61,7 @@ function RateLimit(options) {
 
             req.rateLimit = {
               limit: options.max,
+              current,
               remaining: Math.max(options.max - current, 0)
             };
             

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -61,7 +61,7 @@ function RateLimit(options) {
 
             req.rateLimit = {
               limit: options.max,
-              current,
+              current: current,
               remaining: Math.max(options.max - current, 0)
             };
             


### PR DESCRIPTION
Current limit helps to do deep analysis in sudden spike of request in the handler.