### PR TITLE
Runs in electron where setInterval() returns only a number

### DIFF
--- a/lib/memory-store.js
+++ b/lib/memory-store.js
@@ -22,7 +22,10 @@ function MemoryStore(windowMs) {
   };
 
   // simply reset ALL hits every windowMs
-  setInterval(this.resetAll, windowMs).unref();
+  var interval = setInterval(this.resetAll, windowMs);
+  if (interval.unref) {
+    interval.unref();
+  }
 }
 
 module.exports = MemoryStore;

--- a/test/memory-store.js
+++ b/test/memory-store.js
@@ -118,4 +118,28 @@ describe('MemoryStore store', function() {
       });
     });
   });
+
+  it("can run in electron where setInterval does not return a Timeout object with an unset function", function(done) {
+    var originalSetInterval = setInterval;
+    var timeoutId = 1;
+    setInterval = function(callback, timeout) {
+      originalSetInterval(callback,timeout);
+      return timeoutId ++;
+    };
+
+    var store = new MemoryStore(-1);
+    var key = "test-store";
+
+    store.incr(key, function(err, value) {
+        if (err) {
+            done(err);
+        } else {
+            if (value === 1) {
+                done();
+            } else {
+                done(new Error("incr did not set the key on the store to 1"));
+            }
+        }
+    });
+  });
 });


### PR DESCRIPTION
We run integration tests in Electron where we were see a different return value from `setInterval()` than in pure node causing `unset` to be undefined.