### PR TITLE
Retry-After header

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ A `req.rateLimit` property is added to all requests with the `limit`, `current`,
 * **max**: max number of connections during `windowMs` milliseconds before sending a 429 response. Defaults to `5`. Set to `0` to disable.
 * **message**: Error message returned when `max` is exceeded. Defaults to `'Too many requests, please try again later.'`
 * **statusCode**: HTTP status code returned when `max` is exceeded. Defaults to `429`.
-* **headers**: Enable header to show request limit and current usage
+* **headers**: Enable headers for request limit (`X-RateLimit-Limit`) and current usage (`X-RateLimit-Remaining`) on all responses and time to wait before retrying (`Retry-After`) when `max` is exceeded.
 * **keyGenerator**: Function used to generate keys. By default user IP address (req.ip) is used. Defaults:
 ```js
 function (req /*, res*/) {
@@ -106,6 +106,9 @@ function (/*req, res*/) {
 * **handler**: The function to execute once the max limit is exceeded. It receives the request and the response objects. The "next" param is available if you need to pass to the next middleware. Defaults:
 ```js
 function (req, res, /*next*/) {
+  if (options.headers) {
+    res.setHeader('Retry-After', Math.ceil(options.windowMs / 1000));
+  }
   res.format({
     html: function(){
       res.status(options.statusCode).end(options.message);

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -21,6 +21,9 @@ function RateLimit(options) {
             return false;
         },
         handler: function (req, res /*, next*/) {
+          if (options.headers) {
+            res.setHeader('Retry-After', Math.ceil(options.windowMs / 1000));
+          }
           res.format({
             html: function(){
               res.status(options.statusCode).end(options.message);
@@ -73,7 +76,6 @@ function RateLimit(options) {
 
             if (options.max && current > options.max) {
               options.onLimitReached(req, res, options);
-              res.setHeader('Retry-After', Math.ceil(options.windowMs / 1000));
               return options.handler(req, res, next);
             }
 

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -69,6 +69,7 @@ function RateLimit(options) {
             if (options.headers) {
               res.setHeader('X-RateLimit-Limit', options.max);
               res.setHeader('X-RateLimit-Remaining', req.rateLimit.remaining);
+              res.setHeader('Retry-After', Math.ceil(options.windowMs / 1000));
             }
 
             if (options.max && current > options.max) {

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -69,11 +69,11 @@ function RateLimit(options) {
             if (options.headers) {
               res.setHeader('X-RateLimit-Limit', options.max);
               res.setHeader('X-RateLimit-Remaining', req.rateLimit.remaining);
-              res.setHeader('Retry-After', Math.ceil(options.windowMs / 1000));
             }
 
             if (options.max && current > options.max) {
               options.onLimitReached(req, res, options);
+              res.setHeader('Retry-After', Math.ceil(options.windowMs / 1000));
               return options.handler(req, res, next);
             }
 

--- a/test/express-rate-limit.js
+++ b/test/express-rate-limit.js
@@ -71,7 +71,7 @@ describe('express-rate-limit node module', function() {
       };
     }
 
-    function goodRequest(errorHandler, successHandler, key, headerCheck, limit, remaining) {
+    function goodRequest(errorHandler, successHandler, key, headerCheck, limit, remaining, retryAfter) {
         var req = request(app)
             .get('/');
         // add optional key parameter
@@ -83,6 +83,7 @@ describe('express-rate-limit node module', function() {
             req
             .expect('x-ratelimit-limit', limit)
             .expect('x-ratelimit-remaining', remaining)
+            .expect('retry-after', retryAfter)
             .expect(200,/response!/)
             .end(function(err, res) {
                 if (err) {
@@ -228,8 +229,8 @@ describe('express-rate-limit node module', function() {
       }
     });
 
-    it("should send correct x-ratelimit-limit and x-ratelimit-remaining and header", function(done) {
-        createAppWith(rateLimit());
+    it("should send correct x-ratelimit-limit and x-ratelimit-remaining and retry-after header", function(done) {
+        createAppWith(rateLimit({windowMs: 59100}));
         goodRequest(done, function( /* err, res */ ) {
             delay = Date.now() - start;
             if (delay > 99) {
@@ -237,7 +238,7 @@ describe('express-rate-limit node module', function() {
             } else {
                 done();
             }
-        }, undefined, true, '5', '4');
+        }, undefined, true, '5', '4', '60');
     });
 
     it("should allow the first request with minimal delay", function(done) {

--- a/test/express-rate-limit.js
+++ b/test/express-rate-limit.js
@@ -81,10 +81,8 @@ describe('express-rate-limit node module', function() {
 
         if(headerCheck){
             req
-            .expect(function(res) {
-                res.header['x-ratelimit-limit'] = limit;
-                res.header['x-ratelimit-remaining'] = remaining;
-            })
+            .expect('x-ratelimit-limit', limit)
+            .expect('x-ratelimit-remaining', remaining)
             .expect(200,/response!/)
             .end(function(err, res) {
                 if (err) {
@@ -230,7 +228,7 @@ describe('express-rate-limit node module', function() {
       }
     });
 
-    it("should send correct x-ratelimit-limit and x-ratelimit-remaining header", function(done) {
+    it("should send correct x-ratelimit-limit and x-ratelimit-remaining and header", function(done) {
         createAppWith(rateLimit());
         goodRequest(done, function( /* err, res */ ) {
             delay = Date.now() - start;
@@ -239,7 +237,7 @@ describe('express-rate-limit node module', function() {
             } else {
                 done();
             }
-        },true, 5, 4);
+        }, undefined, true, '5', '4');
     });
 
     it("should allow the first request with minimal delay", function(done) {


### PR DESCRIPTION
Adds basic support for the `Retry-After` header

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429

I say "basic" as all I have done is return the windowMs in seconds. It would be preferable to actually return how long until the current window will elapse but I might leave that to you @nfriedly :)