### PR TITLE
Pass options to "handler"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 npm-debug.log
+.npmrc
 .idea/

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ function (/*req, res*/) {
     return false;
 }
 ```
-* **handler**: The function to execute once the max limit is exceeded. It receives the request and the response objects. The "next" param is available if you need to pass to the next middleware. Defaults:
+* **handler**: The function to execute once the max limit is exceeded. It receives the request and the response objects, "next" function and options. The "next" param is available if you need to pass to the next middleware. Defaults:
 ```js
-function (req, res, /*next*/) {
+function (req, res, next, options) {
   if (options.headers) {
     res.setHeader('Retry-After', Math.ceil(options.windowMs / 1000));
   }

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -20,7 +20,7 @@ function RateLimit(options) {
         skip: function (/*req, res*/) {
             return false;
         },
-        handler: function (req, res /*, next*/) {
+        handler: function (req, res, next, options) {
           if (options.headers) {
             res.setHeader('Retry-After', Math.ceil(options.windowMs / 1000));
           }
@@ -76,7 +76,7 @@ function RateLimit(options) {
 
             if (options.max && current > options.max) {
               options.onLimitReached(req, res, options);
-              return options.handler(req, res, next);
+              return options.handler(req, res, next, options);
             }
 
             if (options.delayAfter && options.delayMs && current > options.delayAfter) {


### PR DESCRIPTION
Current implementation:
```js
function (req, res, /*next*/) {
  if (options.headers) {
    res.setHeader('Retry-After', Math.ceil(options.windowMs / 1000));
  }
  res.format({
    html: function(){
      res.status(options.statusCode).end(options.message);
    },
    json: function(){
      res.status(options.statusCode).json({ message: options.message });
    }
  });
}
```
Ok, but what if for example I want to change it a bit:
```js
function (req, res, /*next*/) {
  if (options.headers) {
    res.setHeader('Retry-After', Math.ceil(options.windowMs / 1000));
  }
  res.status(options.statusCode).json({ message: options.message });
}
```
In this case I don't have `options`, so I will not have `options.headers`, `options.windowMs`, etc.
This PR fixes that.