### PR TITLE
Fixed store links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ If you need a more robust solution, I recommend using an addon store or trying o
 
 ### Stores
 
-* Memory Store (default, built-in) - stores hits in-memory in the Node.js process. Does not share state with other servers or processes.
-* [Redis Store][rate-limit-redis]
+* Memory Store _(default, built-in)_ - stores hits in-memory in the Node.js process. Does not share state with other servers or processes.
+* [Redis Store](https://npmjs.com/package/rate-limit-redis)
 * [Memcached Store](https://npmjs.org/package/rate-limit-memcached)
 
 ### Alternate Rate-limiters
 
-This module was designed to only handle the basics and didn't even support external stores initially. Thes other options all are excellent pieces of software and may be more appropriate for some situations:
+This module was designed to only handle the basics and didn't even support external stores initially. These other options all are excellent pieces of software and may be more appropriate for some situations:
 
 * [strict-rate-limiter](https://www.npmjs.com/package/strict-rate-limiter)
 * [express-brute](https://www.npmjs.com/package/express-brute)
@@ -187,8 +187,10 @@ function SomeStore() {
 ```
 
   Avaliable data stores are:
-   * MemoryStore: (default)Simple in-memory option. Does not share state when app has multiple processes or servers.
-   * [rate-limit-redis]: [Redis](http://redis.io/)-backed store, more suitable for large or demanding deployments.
+   * MemoryStore: _(default)_ Simple in-memory option. Does not share state when app has multiple processes or servers.
+   * [rate-limit-redis](https://npmjs.com/package/rate-limit-redis): A [Redis](http://redis.io/)-backed store, more suitable for large or demanding deployments.
+   * [rate-limit-memcached](https://npmjs.org/package/rate-limit-memcached): A [Memcached](https://memcached.org/)-backed store.
+
 
 The `delayAfter` and `delayMs` options were written for human-facing pages such as login and password reset forms.
 For public APIs, setting these to `0` (disabled) and relying on only `windowMs` and `max` for rate-limiting usually makes the most sense.
@@ -205,5 +207,3 @@ v2 uses a less precise but less resource intensive method of tracking hits from 
 ## License
 
 MIT © [Nathan Friedly](http://nfriedly.com/)
-
-[rate-limit-redis]: https://npmjs.org/package/rate-limit-redis


### PR DESCRIPTION
The link to the Redis store is only working on while viewing the docs on github.  

While viewing on npmjs.com clicking the link directs me to
https://github.com/nfriedly/express-rate-limit/blob/HEAD/%5BRedis%5D(http:/redis.io/)-backed%20store,%20more%20suitable%20for%20large%20or%20demanding%20deployments.
 which is a 404 Page not found for me.

Also the redis link is missing from the lower store list on npm (not on github)
see the below screenshot
![screen shot 2018-08-07 at 12 56 39 pm](https://user-images.githubusercontent.com/4225069/43791011-4f2cba58-9a42-11e8-8839-26af53791720.png)

I fixed the links in both places.