### PR TITLE
Fix Date response header format

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -70,7 +70,6 @@ function RateLimit(options) {
         res.setHeader("X-RateLimit-Remaining", req.rateLimit.remaining);
         if (resetTime) {
           // if we have a resetTime, also provide the current date to help avoid issues with incorrect clocks
-          // format from https://stackoverflow.com/a/13219636/933879
           res.setHeader("Date", new Date().toGMTString());
           res.setHeader("X-RateLimit-Reset", resetTime);
         }

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -71,13 +71,7 @@ function RateLimit(options) {
         if (resetTime) {
           // if we have a resetTime, also provide the current date to help avoid issues with incorrect clocks
           // format from https://stackoverflow.com/a/13219636/933879
-          res.setHeader(
-            "Date",
-            new Date()
-              .toISOString()
-              .replace(/T/, " ")
-              .replace(/\..+/, "")
-          );
+          res.setHeader("Date", new Date().toGMTString());
           res.setHeader("X-RateLimit-Reset", resetTime);
         }
       }


### PR DESCRIPTION
Closes #94.

If this is the appropriate way to resolve, it ought to be back-ported to express-rate-limit v2 as well.