### PR TITLE
Fixed express-slow-down url

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Avaliable data stores are:
 
 ## v3 Changes
 
-- Removed `delayAfter` and `delayMs` options; they were moved to a new module: [express-slow-down](https://npmjs.org/package/express-rate-limit).
+- Removed `delayAfter` and `delayMs` options; they were moved to a new module: [express-slow-down](https://npmjs.org/package/express-slow-down).
 - Simplified the default `handler` function so that it no longer changes the response format. Now uses [res.send](https://expressjs.com/en/4x/api.html#res.send).
 - `onLimitReached` now only triggers once for a given ip and window. only `handle` is called for every blocked request.
 


### PR DESCRIPTION
Very minor change, but confused me while upgrading to version 3