### PR TITLE
Fixed NaN remaining when max is a function

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -67,7 +67,7 @@ function RateLimit(options) {
           req.rateLimit = {
             limit: max,
             current: current,
-            remaining: Math.max(options.max - current, 0),
+            remaining: Math.max(max - current, 0),
             resetTime: resetTime
           };
 


### PR DESCRIPTION
This bug rose from https://github.com/nfriedly/express-rate-limit/releases/tag/v3.2.0 where max can now be a function (which is extremely useful btw so thanks!).

Please merge at your earliest convenience so that we can start using max as a function.
Thanks!