### PR TITLE
add close and error event handlers for response, actualize readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,12 @@ function (req, res, options) {
 
 ### skipFailedRequests
 
-When set to `true`, failed requests (response status >= 400) won't be counted.
+When set to `true`, failed requests won't be counted. Request considered failed when:
+
+- response status >= 400
+- requests that were cancelled before last chunk of data was sent (response `close` event triggered)
+- response `error` event was triggrered by response
+
 (Technically they are counted and then un-counted, so a large number of slow requests all at once could still trigger a rate-limit. This may be fixed in a future release.)
 
 Defaults to `false`.

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -95,20 +95,34 @@ function RateLimit(options) {
             return options.handler(req, res, next);
           }
 
-          if (options.skipFailedRequests) {
-            res.on("finish", function() {
-              if (res.statusCode >= 400) {
+          if (options.skipFailedRequests || options.skipSuccessfulRequests) {
+            let decremented = false;
+            const decrementKey = () => {
+              if (!decremented) {
                 options.store.decrement(key);
+                decremented = true;
               }
-            });
-          }
+            };
 
-          if (options.skipSuccessfulRequests) {
-            res.on("finish", function() {
-              if (res.statusCode < 400) {
-                options.store.decrement(key);
-              }
-            });
+            if (options.skipFailedRequests) {
+              res.on("finish", function() {
+                if (res.statusCode >= 400) {
+                  decrementKey();
+                }
+              });
+
+              res.on("close", () => decrementKey());
+
+              res.on("error", () => decrementKey());
+            }
+
+            if (options.skipSuccessfulRequests) {
+              res.on("finish", function() {
+                if (res.statusCode < 400) {
+                  options.store.decrement(key);
+                }
+              });
+            }
           }
 
           next();


### PR DESCRIPTION
Right now in case request was terminated by client side, or in case of something very unpredictable happens and response will trigger `error` event counter doesn't decrement with options `skipFailedRequests` and `skipSuccessfulRequests` set.

Added counter decrement on response events `close` and `error`. This would happen only if option `skipFailedRequests` is set.