### PR TITLE
decrement store counter on 429 response status

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -84,17 +84,6 @@ function RateLimit(options) {
             }
           }
 
-          if (max && current === max + 1) {
-            options.onLimitReached(req, res, options);
-          }
-
-          if (max && current > max) {
-            if (options.headers) {
-              res.setHeader("Retry-After", Math.ceil(options.windowMs / 1000));
-            }
-            return options.handler(req, res, next);
-          }
-
           if (options.skipFailedRequests || options.skipSuccessfulRequests) {
             let decremented = false;
             const decrementKey = () => {
@@ -123,6 +112,17 @@ function RateLimit(options) {
                 }
               });
             }
+          }
+
+          if (max && current === max + 1) {
+            options.onLimitReached(req, res, options);
+          }
+
+          if (max && current > max) {
+            if (options.headers) {
+              res.setHeader("Retry-After", Math.ceil(options.windowMs / 1000));
+            }
+            return options.handler(req, res, next);
           }
 
           next();

--- a/test/express-rate-limit-test.js
+++ b/test/express-rate-limit-test.js
@@ -82,20 +82,23 @@ describe("express-rate-limit node module", function() {
     this.incr_was_called = false;
     this.resetKey_was_called = false;
     this.decrement_was_called = false;
+    this.counter = 0;
 
-    const self = this;
-    this.incr = function(key, cb) {
-      self.incr_was_called = true;
+    this.incr = (key, cb) => {
+      this.counter++;
+      this.incr_was_called = true;
 
-      cb(null, 1);
+      cb(null, this.counter);
     };
 
-    this.decrement = function() {
-      self.decrement_was_called = true;
+    this.decrement = () => {
+      this.counter--;
+      this.decrement_was_called = true;
     };
 
-    this.resetKey = function() {
-      self.resetKey_was_called = true;
+    this.resetKey = () => {
+      this.resetKey_was_called = true;
+      this.counter = 0;
     };
   }
 
@@ -639,5 +642,26 @@ describe("express-rate-limit node module", function() {
           done();
         }
       });
+  });
+
+  it("should decrement hits with IP hits reached max and skipFailedRequests", done => {
+    const store = new MockStore();
+    createAppWith(
+      rateLimit({
+        delayMs: 0,
+        max: 2,
+        store: store,
+        skipFailedRequests: true
+      })
+    );
+    goodRequest(done);
+    goodRequest(done);
+    badRequest(done, () => {
+      if (!store.decrement_was_called) {
+        done(new Error("decrement was not called on the store"));
+      } else {
+        done();
+      }
+    });
   });
 });


### PR DESCRIPTION
Right now, even if `skipFailedRequests` option is set, store decrement method isn't called, but as said in docs, with this options responses with statuses >= 400 shouldn't be counted. Fixed this and added test for this particular case