### PR TITLE
fix response close event for node v11.x.x

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -111,7 +111,11 @@ function RateLimit(options) {
                 }
               });
 
-              res.on("close", () => decrementKey());
+              res.on("close", () => {
+                if (!res.finished) {
+                  decrementKey();
+                }
+              });
 
               res.on("error", () => decrementKey());
             }

--- a/test/express-rate-limit-test.js
+++ b/test/express-rate-limit-test.js
@@ -571,6 +571,27 @@ describe("express-rate-limit node module", function() {
     });
   });
 
+  it("should not decrement hits with failed response and skipSuccessfulRequests", done => {
+    const store = new MockStore();
+    createAppWith(
+      rateLimit({
+        skipSuccessfulRequests: true,
+        store: store
+      })
+    );
+
+    request(app)
+      .get("/bad_response_status")
+      .expect(403)
+      .end(() => {
+        if (store.decrement_was_called) {
+          done(new Error("decrement was called on the store"));
+        } else {
+          done();
+        }
+      });
+  });
+
   it("should decrement hits with failed response and skipFailedRequests", done => {
     const store = new MockStore();
     createAppWith(
@@ -639,5 +660,23 @@ describe("express-rate-limit node module", function() {
           done();
         }
       });
+  });
+
+  it("should not decrement hits with success response and skipFailedRequests", done => {
+    const store = new MockStore();
+    createAppWith(
+      rateLimit({
+        skipFailedRequests: true,
+        store: store
+      })
+    );
+
+    goodRequest(done, function() {
+      if (store.decrement_was_called) {
+        done(new Error("decrement was called on the store"));
+      } else {
+        done();
+      }
+    });
   });
 });


### PR DESCRIPTION
Since node v11.x.x behaviour of response `close` event changed and now it's triggered always, whether `response.end()` was called or not. So i added `res.finished` check in close event handler and also added some tests.