### PR TITLE
Fix type of message to match Request.send

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { RequestHandler, Request, Response, NextFunction } from 'express';
 
 export interface Options {
     max?: number;
-    message?: string;
+    message?: any;
     headers?: boolean;
     windowMs?: number;
     store: Store | any;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "repository": "nfriedly/express-rate-limit",
   "license": "MIT",
   "main": "lib/express-rate-limit.js",
+  "types": "index.d.ts",
   "files": [
     "lib/"
   ],


### PR DESCRIPTION
The `send` function on Express.Request is typed as accepting `any` value. Since the documentation states the `message` option will be directly passed to `send`, it makes sense to have the same type here.