### PR TITLE
Include typescript typings in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "main": "lib/express-rate-limit.js",
   "types": "index.d.ts",
   "files": [
-    "lib/"
+    "lib/",
+    "index.d.ts"
   ],
   "keywords": [
     "express-rate-limit",


### PR DESCRIPTION
Just one more thing in the way of the typings, they aren't getting included in the package because of the files prop in package.json. This fixes that