### PR TITLE
Makes Options.store a optional member. Fixes "Property 'store' is mis…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export interface Options {
     message?: any;
     headers?: boolean;
     windowMs?: number;
-    store: Store | any;
+    store?: Store | any;
     statusCode?: number;
     skipFailedRequests?: boolean;
     skipSuccessfulRequests?: boolean;


### PR DESCRIPTION
…sing" error in typescript