### PR TITLE
Detect headers sent before sending headers. 

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -73,7 +73,7 @@ function RateLimit(options) {
             resetTime: resetTime
           };
 
-          if (options.headers) {
+          if (options.headers && !res.headersSent) {
             res.setHeader("X-RateLimit-Limit", max);
             res.setHeader("X-RateLimit-Remaining", req.rateLimit.remaining);
             if (resetTime instanceof Date) {
@@ -125,7 +125,7 @@ function RateLimit(options) {
           }
 
           if (max && current > max) {
-            if (options.headers) {
+            if (options.headers && !res.headersSent) {
               res.setHeader("Retry-After", Math.ceil(options.windowMs / 1000));
             }
             return options.handler(req, res, next);


### PR DESCRIPTION
fixes Error: Can't set headers after they are sent when exception inside controller method is thrown