### PR TITLE
Config for RateLimit standardization headers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ Defaults to `true`.
 
 ### draft_polli_ratelimit_headers
 
-This plugin is to support (eg. eventually via configuration) the new (ratelimit standardization proposal)[https://tools.ietf.org/id/draft-polli-ratelimit-headers-01.html].
+Enable headers conforming to the [ratelimit standardization proposal](https://tools.ietf.org/id/draft-polli-ratelimit-headers-01.html): `RateLimit-Limit`, `RateLimit-Remaining`, and, if the store supports it, `RateLimit-Reset`. May be used in conjunction with, or instead of the `headers` option.
+
+Defaults to `false`, but will likely be changed in the next major release.
 
 ### keyGenerator
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Enable headers for request limit (`X-RateLimit-Limit`) and current usage (`X-Rat
 
 Defaults to `true`.
 
+### draft_polli_ratelimit_headers
+
+This plugin is to support (eg. eventually via configuration) the new (ratelimit standardization proposal)[https://tools.ietf.org/id/draft-polli-ratelimit-headers-01.html].
+
 ### keyGenerator
 
 Function used to generate keys.
@@ -222,7 +226,6 @@ Available data stores are:
 - [rate-limit-redis](https://npmjs.com/package/rate-limit-redis): A [Redis](http://redis.io/)-backed store, more suitable for large or demanding deployments.
 - [rate-limit-memcached](https://npmjs.org/package/rate-limit-memcached): A [Memcached](https://memcached.org/)-backed store.
 - [rate-limit-mongo](https://www.npmjs.com/package/rate-limit-mongo): A [MongoDB](https://www.mongodb.com/)-backed store.
-
 
 You may also create your own store. It must implement the following in order to function:
 

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -71,8 +71,7 @@ function RateLimit(options) {
             limit: max,
             current: current,
             remaining: Math.max(max - current, 0),
-            resetTime: resetTime,
-            deltaSeconds: Math.ceil((resetTime.getTime() - Date.now()) / 1000)
+            resetTime: resetTime
           };
 
           if (options.headers && !res.headersSent) {
@@ -91,10 +90,10 @@ function RateLimit(options) {
             res.setHeader("RateLimit-Limit", max);
             res.setHeader("RateLimit-Remaining", req.rateLimit.remaining);
             if (resetTime) {
-              res.setHeader(
-                "RateLimit-Reset",
-                Math.max(0, req.rateLimit.deltaSeconds)
+              const deltaSeconds = Math.ceil(
+                (resetTime.getTime() - Date.now()) / 1000
               );
+              res.setHeader("RateLimit-Reset", Math.max(0, deltaSeconds));
             }
           }
 

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -71,7 +71,8 @@ function RateLimit(options) {
             limit: max,
             current: current,
             remaining: Math.max(max - current, 0),
-            resetTime: resetTime
+            resetTime: resetTime,
+            deltaSeconds: Math.ceil((resetTime.getTime() - Date.now()) / 1000)
           };
 
           if (options.headers && !res.headersSent) {
@@ -86,15 +87,13 @@ function RateLimit(options) {
               );
             }
           }
-          if (options.draft_polli_ratelimit_headers) {
+          if (options.draft_polli_ratelimit_headers && !res.headersSent) {
             res.setHeader("RateLimit-Limit", max);
             res.setHeader("RateLimit-Remaining", req.rateLimit.remaining);
-            if (resetTime instanceof Date) {
-              // if we have a resetTime, also provide the current date to help avoid issues with incorrect clocks
-              res.setHeader("Date", new Date().toGMTString());
+            if (resetTime) {
               res.setHeader(
                 "RateLimit-Reset",
-                Math.ceil((resetTime.getTime() - Date.now()) / 1000)
+                Math.max(0, req.rateLimit.deltaSeconds)
               );
             }
           }

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -9,6 +9,7 @@ function RateLimit(options) {
       message: "Too many requests, please try again later.",
       statusCode: 429, // 429 status = Too Many Requests (RFC 6585)
       headers: true, //Send custom rate limit header with limit and remaining
+      draft_polli_ratelimit_headers: false, //Support for the new RateLimit standardization headers
       skipFailedRequests: false, // Do not count failed requests (status >= 400)
       skipSuccessfulRequests: false, // Do not count successful requests (status < 400)
       // allows to create custom keys (by default user IP is used)
@@ -82,6 +83,18 @@ function RateLimit(options) {
               res.setHeader(
                 "X-RateLimit-Reset",
                 Math.ceil(resetTime.getTime() / 1000)
+              );
+            }
+          }
+          if (options.draft_polli_ratelimit_headers) {
+            res.setHeader("RateLimit-Limit", max);
+            res.setHeader("RateLimit-Remaining", req.rateLimit.remaining);
+            if (resetTime instanceof Date) {
+              // if we have a resetTime, also provide the current date to help avoid issues with incorrect clocks
+              res.setHeader("Date", new Date().toGMTString());
+              res.setHeader(
+                "RateLimit-Reset",
+                Math.ceil((resetTime.getTime() - Date.now()) / 1000)
               );
             }
           }

--- a/test/express-rate-limit-test.js
+++ b/test/express-rate-limit-test.js
@@ -307,6 +307,28 @@ describe("express-rate-limit node module", function() {
     );
   });
 
+  it("should send correct ratelimit-limit and ratelimit-remaining", function(done) {
+    createAppWith(
+      rateLimit({ windowMs: 59100, draft_polli_ratelimit_headers: true })
+    );
+    goodRequest(
+      done,
+      function(/* err, res */) {
+        delay = Date.now() - start;
+        if (delay > 99) {
+          done(new Error("First request took too long: " + delay + "ms"));
+        } else {
+          done();
+        }
+      },
+      undefined,
+      true,
+      "5",
+      "4",
+      "60"
+    );
+  });
+
   it("should refuse additional connections once IP has reached the max", function(done) {
     createAppWith(
       rateLimit({


### PR DESCRIPTION
For #168 

* Added new option `draft_polli_ratelimit_headers` set to `false`.
* Added the set of new headers `RateLimit-Limit`, `RateLimit-Remaining` and `RateLimit-Reset`.
* Added *draft_polli_ratelimit_headers* in Docs.

