### PR TITLE
IP are always same/localhost fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ Defaults to `false`. Behavior and name will likely change in future releases.
 
 Function used to generate keys.
 
-Defaults to req.ip:
+Defaults to `req.headers['x-forwarded-for'] || req.connection.remoteAddress || req.ip`:
 
 ```js
 function (req /*, res*/) {
-    return req.ip;
+  return req.headers['x-forwarded-for'] || req.connection.remoteAddress || req.ip;
 }
 ```
 

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -14,7 +14,7 @@ function RateLimit(options) {
       skipSuccessfulRequests: false, // Do not count successful requests (status < 400)
       // allows to create custom keys (by default user IP is used)
       keyGenerator: function(req /*, res*/) {
-        return req.ip;
+        return req.headers['x-forwarded-for'] || req.connection.remoteAddress || req.ip;
       },
       skip: function(/*req, res*/) {
         return false;


### PR DESCRIPTION
Hello everyone,

Most (for me it was always) in cases "req.ip" just returned the false IP Address such "::ffff:7f00:1". Which can cause to block all requests from all users even for new user.

With this fix it will allow us to get real IP Addresses and can block request properly.

Let me know if you have any further questions.

Regards,

Yan
