### PR TITLE
Handle exceptions

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -65,7 +65,6 @@ function RateLimit(options) {
         typeof options.max === "function" ? options.max(req, res) : options.max;
 
       Promise.resolve(maxResult)
-        .catch(next)
         .then((max) => {
           req.rateLimit = {
             limit: max,

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -143,7 +143,8 @@ function RateLimit(options) {
           }
 
           next();
-        });
+        })
+        .catch(next);
     });
   }
 

--- a/test/express-rate-limit-test.js
+++ b/test/express-rate-limit-test.js
@@ -658,4 +658,28 @@ describe("express-rate-limit node module", () => {
     rateLimit(opts);
     assert.deepEqual(opts, {});
   });
+
+  it("should handle exceptions", (done) => {
+    const store = new MockStore();
+    const app = createAppWith(
+      rateLimit({
+        max: 1,
+        store: store,
+        handler: () => {
+          const exception = new Error();
+          exception.code = 429;
+          exception.message = "Too many requests";
+          throw exception;
+        },
+      })
+    );
+    app.use((err, req, res, next) => {
+      res.status(err.code).send(err.message);
+      next;
+    });
+    goodRequest(done);
+    badRequest(done, () => {
+      done();
+    });
+  });
 });

--- a/test/express-rate-limit-test.js
+++ b/test/express-rate-limit-test.js
@@ -675,7 +675,7 @@ describe("express-rate-limit node module", () => {
     );
     app.use((err, req, res, next) => {
       res.status(err.code).send(err.message);
-      next;
+      next; // ignore lint errors?
     });
     goodRequest(done);
     badRequest(done, () => {


### PR DESCRIPTION
Allow express to handle exceptions with default error handler. Now, we can throw an exception into `handler` callback if limits reached.

@see https://expressjs.com/en/guide/error-handling.html#the-default-error-handler