### PR TITLE
Change Date.toGMTString to Date.toUTCString due to deprecation

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -82,7 +82,7 @@ function RateLimit(options) {
                 res.setHeader("X-RateLimit-Remaining", req.rateLimit.remaining);
                 if (resetTime instanceof Date) {
                   // if we have a resetTime, also provide the current date to help avoid issues with incorrect clocks
-                  res.setHeader("Date", new Date().toGMTString());
+                  res.setHeader("Date", new Date().toUTCString());
                   res.setHeader(
                     "X-RateLimit-Reset",
                     Math.ceil(resetTime.getTime() / 1000)


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toGMTString

Interestingly, .toGMTString is actually already .toUTCString in node v14
![image](https://user-images.githubusercontent.com/974410/107997084-3e183d00-6fe2-11eb-9cf4-36fb4231f597.png)
