### PR TITLE
BUG: in X-RateLimit-Reset divide date in 1000 instead of milliseconds difference 

### DIFF
--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -50,11 +50,14 @@ function RateLimit(options) {
   });
 
   function rateLimit(req, res, next) {
-
-
-    const setResponseHeaders = ({ max, remaining, resetTime, draftPolliSet }) => {
+    const setResponseHeaders = ({
+      max,
+      remaining,
+      resetTime,
+      draftPolliSet,
+    }) => {
       if (!res.headersSent) {
-        const prefix = draftPolliSet ? "" : "X-"
+        const prefix = draftPolliSet ? "" : "X-";
         res.setHeader(`${prefix}RateLimit-Limit`, max);
         res.setHeader(`${prefix}RateLimit-Remaining`, remaining);
         if (resetTime instanceof Date) {
@@ -68,8 +71,7 @@ function RateLimit(options) {
           res.setHeader(`${prefix}RateLimit-Reset`, Math.max(0, deltaSeconds));
         }
       }
-
-    }
+    };
 
     Promise.resolve(options.skip(req, res))
       .then((skip) => {
@@ -100,11 +102,20 @@ function RateLimit(options) {
 
               const remaining = req.rateLimit.remaining;
               if (options.headers)
-                setResponseHeaders({ max, remaining, resetTime, draftPolliSet: false })
+                setResponseHeaders({
+                  max,
+                  remaining,
+                  resetTime,
+                  draftPolliSet: false,
+                });
 
               if (options.draft_polli_ratelimit_headers)
-                setResponseHeaders({ max, remaining, resetTime, draftPolliSet: true })
-
+                setResponseHeaders({
+                  max,
+                  remaining,
+                  resetTime,
+                  draftPolliSet: true,
+                });
 
               if (
                 options.skipFailedRequests ||

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -50,6 +50,27 @@ function RateLimit(options) {
   });
 
   function rateLimit(req, res, next) {
+
+
+    const setResponseHeaders = ({ max, remaining, resetTime, draftPolliSet }) => {
+      if (!res.headersSent) {
+        const prefix = draftPolliSet ? "" : "X-"
+        res.setHeader(`${prefix}RateLimit-Limit`, max);
+        res.setHeader(`${prefix}RateLimit-Remaining`, remaining);
+        if (resetTime instanceof Date) {
+          if (!draftPolliSet) {
+            // if we have a resetTime, also provide the current date to help avoid issues with incorrect clocks
+            res.setHeader("Date", new Date().toUTCString());
+          }
+          const deltaSeconds = Math.ceil(
+            (resetTime.getTime() - Date.now()) / 1000
+          );
+          res.setHeader(`${prefix}RateLimit-Reset`, Math.max(0, deltaSeconds));
+        }
+      }
+
+    }
+
     Promise.resolve(options.skip(req, res))
       .then((skip) => {
         if (skip) {
@@ -77,28 +98,13 @@ function RateLimit(options) {
                 resetTime: resetTime,
               };
 
-              if (options.headers && !res.headersSent) {
-                res.setHeader("X-RateLimit-Limit", max);
-                res.setHeader("X-RateLimit-Remaining", req.rateLimit.remaining);
-                if (resetTime instanceof Date) {
-                  // if we have a resetTime, also provide the current date to help avoid issues with incorrect clocks
-                  res.setHeader("Date", new Date().toUTCString());
-                  res.setHeader(
-                    "X-RateLimit-Reset",
-                    Math.ceil(resetTime.getTime() / 1000)
-                  );
-                }
-              }
-              if (options.draft_polli_ratelimit_headers && !res.headersSent) {
-                res.setHeader("RateLimit-Limit", max);
-                res.setHeader("RateLimit-Remaining", req.rateLimit.remaining);
-                if (resetTime) {
-                  const deltaSeconds = Math.ceil(
-                    (resetTime.getTime() - Date.now()) / 1000
-                  );
-                  res.setHeader("RateLimit-Reset", Math.max(0, deltaSeconds));
-                }
-              }
+              const remaining = req.rateLimit.remaining;
+              if (options.headers)
+                setResponseHeaders({ max, remaining, resetTime, draftPolliSet: false })
+
+              if (options.draft_polli_ratelimit_headers)
+                setResponseHeaders({ max, remaining, resetTime, draftPolliSet: true })
+
 
               if (
                 options.skipFailedRequests ||

--- a/test/headers-test.js
+++ b/test/headers-test.js
@@ -23,21 +23,13 @@ describe("headers", () => {
       })
     );
     const expectedRemaining = 4;
-
-    // build a regex that matches the expected timestamp except for the last two digits
-    const expectedResetTimestamp = Math.ceil(
-      (Date.now() + windowMs) / 1000
-    ).toString();
-    const resetRegexp = new RegExp(
-      expectedResetTimestamp.substr(0, expectedResetTimestamp.length - 2) +
-        "\\d\\d"
-    );
+    const expectedResetTimeInSeconds = windowMs / 1000;
 
     await request(app)
       .get("/")
       .expect("x-ratelimit-limit", limit.toString())
       .expect("x-ratelimit-remaining", expectedRemaining.toString())
-      .expect("x-ratelimit-reset", resetRegexp)
+      .expect("x-ratelimit-reset", expectedResetTimeInSeconds.toString())
       .expect(200, /response!/);
   });
 


### PR DESCRIPTION
closes #232

- fix X-RateLimit-Reset header weird response
- validate **resetTime** is instance of Date when using **draft_polli_ratelimit_headers**
- merge common header creation logic to reusable function
