### PR TITLE
Ability to manually decide if request was successful

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ function (req, res, options) {
 }
 ```
 
+### requestWasSuccessful
+
+Function that is called when `skipFailedRequests` and/or `skipSuccessfulRequests` are set to `true`.
+Could be useful for manual decision if request was successful based on request/response.
+
+Defaults to
+
+```js
+function (req, res) {
+    return res.statusCode < 400;
+}
+```
+
 ### skipFailedRequests
 
 When set to `true`, failed requests won't be counted. Request considered failed when:
@@ -201,9 +214,6 @@ Defaults to `false`.
 ### skipSuccessfulRequests
 
 When set to `true` successful requests (response status < 400) won't be counted.
-
-Could be set to `skipSuccessfulRequests: function (req, res): boolean`. Used to manually decide if request was successful and therefore should not be counted.
-
 (Technically they are counted and then un-counted, so a large number of slow requests all at once could still trigger a rate-limit. This may be fixed in a future release.)
 
 Defaults to `false`.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ Defaults to `false`.
 ### skipSuccessfulRequests
 
 When set to `true` successful requests (response status < 400) won't be counted.
+
+Could be set to `skipSuccessfulRequests: function (req, res): boolean`. Used to manually decide if request was successful and therefore should not be counted.
+
 (Technically they are counted and then un-counted, so a large number of slow requests all at once could still trigger a rate-limit. This may be fixed in a future release.)
 
 Defaults to `false`.

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -10,12 +10,12 @@ function RateLimit(options) {
       statusCode: 429, // 429 status = Too Many Requests (RFC 6585)
       headers: true, //Send custom rate limit header with limit and remaining
       draft_polli_ratelimit_headers: false, //Support for the new RateLimit standardization headers
-      skipFailedRequests: false, // Do not count failed requests (status >= 400)
-      skipSuccessfulRequests: false, // Do not count successful requests (status < 400)
-      // allows to manually decide if request was successful and should be skipped
-      // skipSuccessfulRequests: function (req, res) {
-      //   return res.statusCode < 400;
-      // },
+      // ability to manually decide if request was successful. Used when `skipSuccessfulRequests` and/or `skipFailedRequests` are set to `true`
+      requestWasSuccessful: function (req, res) {
+        return res.statusCode < 400;
+      },
+      skipFailedRequests: false, // Do not count failed requests
+      skipSuccessfulRequests: false, // Do not count successful requests
       // allows to create custom keys (by default user IP is used)
       keyGenerator: function (req /*, res*/) {
         return req.ip;
@@ -104,18 +104,9 @@ function RateLimit(options) {
                 }
               }
 
-              const skipSuccessfulRequests =
-                typeof options.skipSuccessfulRequests === "function"
-                  ? options.skipSuccessfulRequests
-                  : function (req, res) {
-                      return options.skipSuccessfulRequests
-                        ? res.statusCode < 400
-                        : false;
-                    };
-
               if (
                 options.skipFailedRequests ||
-                skipSuccessfulRequests(req, res)
+                options.skipSuccessfulRequests
               ) {
                 let decremented = false;
                 const decrementKey = () => {
@@ -127,7 +118,7 @@ function RateLimit(options) {
 
                 if (options.skipFailedRequests) {
                   res.on("finish", function () {
-                    if (res.statusCode >= 400) {
+                    if (!options.requestWasSuccessful(req, res)) {
                       decrementKey();
                     }
                   });
@@ -141,11 +132,13 @@ function RateLimit(options) {
                   res.on("error", () => decrementKey());
                 }
 
-                res.on("finish", function () {
-                  if (skipSuccessfulRequests(req, res)) {
-                    options.store.decrement(key);
-                  }
-                });
+                if (options.skipSuccessfulRequests) {
+                  res.on("finish", function () {
+                    if (options.requestWasSuccessful(req, res)) {
+                      options.store.decrement(key);
+                    }
+                  });
+                }
               }
 
               if (max && current === max + 1) {

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -12,6 +12,10 @@ function RateLimit(options) {
       draft_polli_ratelimit_headers: false, //Support for the new RateLimit standardization headers
       skipFailedRequests: false, // Do not count failed requests (status >= 400)
       skipSuccessfulRequests: false, // Do not count successful requests (status < 400)
+      // allows to manually decide if request was successful and should be skipped
+      // skipSuccessfulRequests: function (req, res) {
+      //   return res.statusCode < 400;
+      // },
       // allows to create custom keys (by default user IP is used)
       keyGenerator: function (req /*, res*/) {
         return req.ip;
@@ -100,9 +104,18 @@ function RateLimit(options) {
                 }
               }
 
+              const skipSuccessfulRequests =
+                typeof options.skipSuccessfulRequests === "function"
+                  ? options.skipSuccessfulRequests
+                  : function (req, res) {
+                      return options.skipSuccessfulRequests
+                        ? res.statusCode < 400
+                        : false;
+                    };
+
               if (
                 options.skipFailedRequests ||
-                options.skipSuccessfulRequests
+                skipSuccessfulRequests(req, res)
               ) {
                 let decremented = false;
                 const decrementKey = () => {
@@ -128,13 +141,11 @@ function RateLimit(options) {
                   res.on("error", () => decrementKey());
                 }
 
-                if (options.skipSuccessfulRequests) {
-                  res.on("finish", function () {
-                    if (res.statusCode < 400) {
-                      options.store.decrement(key);
-                    }
-                  });
-                }
+                res.on("finish", function () {
+                  if (skipSuccessfulRequests(req, res)) {
+                    options.store.decrement(key);
+                  }
+                });
               }
 
               if (max && current === max + 1) {

--- a/test/express-rate-limit-test.js
+++ b/test/express-rate-limit-test.js
@@ -438,7 +438,7 @@ describe("express-rate-limit node module", () => {
     );
 
     await request(app).get("/").expect(200);
-    assert(store.decrement_was_called, "decrement was not called on the store");
+    assert(store.decrement_was_called, "decrement was called on the store");
   });
 
   it("should not decrement hits with success response with custom 'requestWasSuccessful' option", async () => {
@@ -455,7 +455,7 @@ describe("express-rate-limit node module", () => {
 
     await request(app).get("/bad_response_status").expect(403);
 
-    assert(!store.decrement_was_called, "decrement was called on the store");
+    assert(!store.decrement_was_called, "decrement was not called on the store");
   });
 
   it("should decrement hits with failed response and skipFailedRequests", async () => {

--- a/test/express-rate-limit-test.js
+++ b/test/express-rate-limit-test.js
@@ -425,6 +425,37 @@ describe("express-rate-limit node module", () => {
     assert(!store.decrement_was_called, "decrement was called on the store");
   });
 
+  it("should decrement hits with success response and skipSuccessfulRequests: statusCode < 400", async () => {
+    const store = new MockStore();
+    createAppWith(
+      rateLimit({
+        skipSuccessfulRequests: function (req, res) {
+          return res.statusCode < 400;
+        },
+        store: store,
+      })
+    );
+
+    await request(app).get("/").expect(200);
+    assert(store.decrement_was_called, "decrement was not called on the store");
+  });
+
+  it("should not decrement hits with failed response and skipSuccessfulRequests: statusCode < 400", async () => {
+    const store = new MockStore();
+    createAppWith(
+      rateLimit({
+        skipSuccessfulRequests: function (req, res) {
+          return res.statusCode < 400;
+        },
+        store: store,
+      })
+    );
+
+    await request(app).get("/bad_response_status").expect(403);
+
+    assert(!store.decrement_was_called, "decrement was called on the store");
+  });
+
   it("should decrement hits with failed response and skipFailedRequests", async () => {
     const store = new MockStore();
     createAppWith(

--- a/test/express-rate-limit-test.js
+++ b/test/express-rate-limit-test.js
@@ -458,6 +458,40 @@ describe("express-rate-limit node module", () => {
     assert(!store.decrement_was_called, "decrement was not called on the store");
   });
 
+  it("should decrement hits with success response with custom 'requestWasSuccessful' option based on query parameter", async () => {
+    const store = new MockStore();
+    createAppWith(
+      rateLimit({
+        skipSuccessfulRequests: true,
+        requestWasSuccessful: function (req) {
+          return req.query.success === "1";
+        },
+        store: store,
+      })
+    );
+
+    await request(app).get("/?success=1");
+
+    assert(store.decrement_was_called, "decrement was called on the store");
+  });
+
+  it("should not decrement hits with failed response with custom 'requestWasSuccessful' option based on query parameter", async () => {
+    const store = new MockStore();
+    createAppWith(
+      rateLimit({
+        skipSuccessfulRequests: true,
+        requestWasSuccessful: function (req) {
+          return req.query.success === "1";
+        },
+        store: store,
+      })
+    );
+
+    await request(app).get("/?success=0");
+
+    assert(!store.decrement_was_called, "decrement was not called on the store");
+  });
+
   it("should decrement hits with failed response and skipFailedRequests", async () => {
     const store = new MockStore();
     createAppWith(

--- a/test/express-rate-limit-test.js
+++ b/test/express-rate-limit-test.js
@@ -425,12 +425,13 @@ describe("express-rate-limit node module", () => {
     assert(!store.decrement_was_called, "decrement was called on the store");
   });
 
-  it("should decrement hits with success response and skipSuccessfulRequests: statusCode < 400", async () => {
+  it("should decrement hits with success response with custom 'requestWasSuccessful' option", async () => {
     const store = new MockStore();
     createAppWith(
       rateLimit({
-        skipSuccessfulRequests: function (req, res) {
-          return res.statusCode < 400;
+        skipSuccessfulRequests: true,
+        requestWasSuccessful: function (req, res) {
+          return res.statusCode === 200;
         },
         store: store,
       })
@@ -440,12 +441,13 @@ describe("express-rate-limit node module", () => {
     assert(store.decrement_was_called, "decrement was not called on the store");
   });
 
-  it("should not decrement hits with failed response and skipSuccessfulRequests: statusCode < 400", async () => {
+  it("should not decrement hits with success response with custom 'requestWasSuccessful' option", async () => {
     const store = new MockStore();
     createAppWith(
       rateLimit({
-        skipSuccessfulRequests: function (req, res) {
-          return res.statusCode < 400;
+        skipSuccessfulRequests: true,
+        requestWasSuccessful: function (req, res) {
+          return res.statusCode === 200;
         },
         store: store,
       })


### PR DESCRIPTION
This PR adds ability to decide if request was successful (and as the result should be skipped) manually, based on request and/or response.

I had a use-case when comparison against `response.statusCode` wasn't enough, because application always responds with redirects to static pages (3xx) if error happened

Hope, this feature could be useful for community 🙌 
_Backward compatibility is saved_