### PR TITLE
add option to allow  custom param name added to req

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ app.post("/create-account", createAccountLimiter, function(req, res) {
 
 A `req.rateLimit` property is added to all requests with the `limit`, `current`, and `remaining` number of requests and, if the store provides it, a `resetTime` Date object. These may be used in your application code to take additional actions or inform the user of their status.
 
-The property name can be configured with the configuration option `reqRateLimitParam`
+The property name can be configured with the configuration option `requestPropertyName`
 
 ## Configuration options
 
@@ -232,7 +232,7 @@ function (/*req, res*/) {
 }
 ```
 
-### reqRateLimitParam
+### requestPropertyName
 Parameter to add to `req`-Object. 
 
 Defaults to `rateLimit`.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ app.post("/create-account", createAccountLimiter, function(req, res) {
 
 A `req.rateLimit` property is added to all requests with the `limit`, `current`, and `remaining` number of requests and, if the store provides it, a `resetTime` Date object. These may be used in your application code to take additional actions or inform the user of their status.
 
+The property name can be configured with the configuration option `reqRateLimitParam`
+
 ## Configuration options
 
 ### max
@@ -229,6 +231,11 @@ function (/*req, res*/) {
     return false;
 }
 ```
+
+### reqRateLimitParam
+Parameter to add to `req`-Object. 
+
+Defaults to `rateLimit`.
 
 ### store
 

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -27,6 +27,7 @@ function RateLimit(options) {
         res.status(options.statusCode).send(options.message);
       },
       onLimitReached: function (/*req, res, optionsUsed*/) {},
+      reqRateLimitParam: "rateLimit", // Parameter name appended to req object
     },
     options
   );
@@ -74,7 +75,7 @@ function RateLimit(options) {
 
           Promise.resolve(maxResult)
             .then((max) => {
-              req.rateLimit = {
+              req[options.reqRateLimitParam] = {
                 limit: max,
                 current: current,
                 remaining: Math.max(max - current, 0),
@@ -83,7 +84,7 @@ function RateLimit(options) {
 
               if (options.headers && !res.headersSent) {
                 res.setHeader("X-RateLimit-Limit", max);
-                res.setHeader("X-RateLimit-Remaining", req.rateLimit.remaining);
+                res.setHeader("X-RateLimit-Remaining", req[options.reqRateLimitParam].remaining);
                 if (resetTime instanceof Date) {
                   // if we have a resetTime, also provide the current date to help avoid issues with incorrect clocks
                   res.setHeader("Date", new Date().toUTCString());
@@ -95,7 +96,7 @@ function RateLimit(options) {
               }
               if (options.draft_polli_ratelimit_headers && !res.headersSent) {
                 res.setHeader("RateLimit-Limit", max);
-                res.setHeader("RateLimit-Remaining", req.rateLimit.remaining);
+                res.setHeader("RateLimit-Remaining", req[options.reqRateLimitParam].remaining);
                 if (resetTime) {
                   const deltaSeconds = Math.ceil(
                     (resetTime.getTime() - Date.now()) / 1000
@@ -175,4 +176,4 @@ function RateLimit(options) {
   return rateLimit;
 }
 
-module.exports = RateLimit;
+module.exports = RateLimit; 

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -27,7 +27,7 @@ function RateLimit(options) {
         res.status(options.statusCode).send(options.message);
       },
       onLimitReached: function (/*req, res, optionsUsed*/) {},
-      reqRateLimitParam: "rateLimit", // Parameter name appended to req object
+      requestPropertyName: "rateLimit", // Parameter name appended to req object
     },
     options
   );
@@ -75,7 +75,7 @@ function RateLimit(options) {
 
           Promise.resolve(maxResult)
             .then((max) => {
-              req[options.reqRateLimitParam] = {
+              req[options.requestPropertyName] = {
                 limit: max,
                 current: current,
                 remaining: Math.max(max - current, 0),
@@ -84,7 +84,10 @@ function RateLimit(options) {
 
               if (options.headers && !res.headersSent) {
                 res.setHeader("X-RateLimit-Limit", max);
-                res.setHeader("X-RateLimit-Remaining", req[options.reqRateLimitParam].remaining);
+                res.setHeader(
+                  "X-RateLimit-Remaining",
+                  req[options.requestPropertyName].remaining
+                );
                 if (resetTime instanceof Date) {
                   // if we have a resetTime, also provide the current date to help avoid issues with incorrect clocks
                   res.setHeader("Date", new Date().toUTCString());
@@ -96,7 +99,10 @@ function RateLimit(options) {
               }
               if (options.draft_polli_ratelimit_headers && !res.headersSent) {
                 res.setHeader("RateLimit-Limit", max);
-                res.setHeader("RateLimit-Remaining", req[options.reqRateLimitParam].remaining);
+                res.setHeader(
+                  "RateLimit-Remaining",
+                  req[options.requestPropertyName].remaining
+                );
                 if (resetTime) {
                   const deltaSeconds = Math.ceil(
                     (resetTime.getTime() - Date.now()) / 1000
@@ -176,4 +182,4 @@ function RateLimit(options) {
   return rateLimit;
 }
 
-module.exports = RateLimit; 
+module.exports = RateLimit;


### PR DESCRIPTION
Allow to rename the req.rateLimit parameter. Useful if using more than one rateLimiter with different keys.