### PR TITLE
Add precision configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ Defaults to `60000` (1 minute).
 
 Number of request buckets inside time window. Buckets group requests based on timestamp for efficient cleanup.
 
-With precision set to `1` all remembered requests are reset, when time window expires. Increasing this value too much will result in decreased performance.
+This option is currently utilized only by `memory-store`, other stores rely on databases with "infinite" per request precision. With precision set to `1` all remembered requests are reset, when time window expires. Increasing this value too much will result in decreased performance.
 
-Defaults to `4`.
+Defaults to `1`.
 
 ### message
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Note: with non-default stores, you may need to configure this value twice, once 
 
 Defaults to `60000` (1 minute).
 
+### precision
+
+Number of request buckets inside time window. Buckets group requests based on timestamp for efficient cleanup.
+
+With precision set to `1` all remembered requests are reset, when time window expires. Increasing this value too much will result in decreased performance.
+
+Defaults to `4`.
+
 ### message
 
 Error message sent to user when `max` is exceeded.

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -10,6 +10,7 @@ function RateLimit(options) {
       statusCode: 429, // 429 status = Too Many Requests (RFC 6585)
       headers: true, //Send custom rate limit header with limit and remaining
       draft_polli_ratelimit_headers: false, //Support for the new RateLimit standardization headers
+      precision: 4, //Number of request buckets inside time window. Buckets serve as a performant alternative to tracking timestamp of each request and clearing them one by one.
       // ability to manually decide if request was successful. Used when `skipSuccessfulRequests` and/or `skipFailedRequests` are set to `true`
       requestWasSuccessful: function (req, res) {
         return res.statusCode < 400;
@@ -31,8 +32,13 @@ function RateLimit(options) {
     options
   );
 
+  if (options.precision <= 0) {
+    throw new Error("Rate limiter precision must be positive number");
+  }
+
   // store to use for persisting rate limit data
-  options.store = options.store || new MemoryStore(options.windowMs);
+  options.store =
+    options.store || new MemoryStore(options.windowMs, options.precision);
 
   // ensure that the store has the incr method
   if (

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -10,7 +10,7 @@ function RateLimit(options) {
       statusCode: 429, // 429 status = Too Many Requests (RFC 6585)
       headers: true, //Send custom rate limit header with limit and remaining
       draft_polli_ratelimit_headers: false, //Support for the new RateLimit standardization headers
-      precision: 4, //Number of request buckets inside time window. Buckets serve as a performant alternative to tracking timestamp of each request and clearing them one by one.
+      precision: 1, //Number of request buckets inside time window. Buckets serve as a performant alternative to tracking timestamp of each request and clearing them one by one.
       // ability to manually decide if request was successful. Used when `skipSuccessfulRequests` and/or `skipFailedRequests` are set to `true`
       requestWasSuccessful: function (req, res) {
         return res.statusCode < 400;

--- a/lib/memory-store.js
+++ b/lib/memory-store.js
@@ -6,41 +6,60 @@ function calculateNextResetTime(windowMs) {
   return d;
 }
 
-function MemoryStore(windowMs) {
-  let hits = {};
+function MemoryStore(windowMs, precision) {
+  // Buckets divide `windowMs` into multiple subparts that can be cleared
+  // individually, allowing for better precision when clearing outdated requests.
+  // After a bucket has expired, all requests that were assigned to it's time window
+  // are removed and the bucket is replaced with new one in a circular buffer manner.
+  let buckets = Array.from({ length: precision }, () => new Object());
+  let currentBucketIdx = 0;
+
   let resetTime = calculateNextResetTime(windowMs);
 
   this.incr = function (key, cb) {
-    if (hits[key]) {
-      hits[key]++;
+    const currentBucket = buckets[currentBucketIdx];
+    if (currentBucket[key]) {
+      currentBucket[key]++;
     } else {
-      hits[key] = 1;
+      currentBucket[key] = 1;
     }
 
-    cb(null, hits[key], resetTime);
+    const keyHits = buckets
+      .map((mappedBucket) => mappedBucket[key] || 0)
+      .reduce((rollingSum, hits) => rollingSum + hits, 0);
+    cb(null, keyHits, resetTime);
   };
 
   this.decrement = function (key) {
-    if (hits[key]) {
-      hits[key]--;
+    const currentBucket = buckets[currentBucketIdx];
+    if (currentBucket[key]) {
+      currentBucket[key]--;
     }
   };
 
   // export an API to allow hits all IPs to be reset
   this.resetAll = function () {
-    hits = {};
+    buckets = Array.from({ length: precision }, () => new Object());
+    currentBucketIdx = 0;
+  };
+
+  this.resetBucket = function () {
     resetTime = calculateNextResetTime(windowMs);
+    currentBucketIdx = (currentBucketIdx + 1) % buckets.length;
+    buckets[currentBucketIdx] = {};
   };
 
   // export an API to allow hits from one IP to be reset
   this.resetKey = function (key) {
-    delete hits[key];
+    for (const bucket of buckets) {
+      delete bucket[key];
+    }
   };
 
-  // simply reset ALL hits every windowMs
-  const interval = setInterval(this.resetAll, windowMs);
-  if (interval.unref) {
-    interval.unref();
+  const bucketTime = windowMs / precision;
+  const bucketResetInterval = setInterval(this.resetBucket, bucketTime);
+  if (bucketResetInterval.unref) {
+    bucketResetInterval.unref();
   }
 }
 

--- a/lib/memory-store.js
+++ b/lib/memory-store.js
@@ -1,9 +1,9 @@
 "use strict";
 
-function calculateNextResetTime(windowMs) {
-  const d = new Date();
-  d.setMilliseconds(d.getMilliseconds() + windowMs);
-  return d;
+function calculateNextResetTime(windowMs, precision) {
+  const date = new Date();
+  date.setMilliseconds(d.getMilliseconds() + (windowMs / precison));
+  return date;
 }
 
 function MemoryStore(windowMs, precision) {
@@ -14,8 +14,8 @@ function MemoryStore(windowMs, precision) {
   let buckets = Array.from({ length: precision }, () => new Object());
   let currentBucketIdx = 0;
 
-  let resetTime = calculateNextResetTime(windowMs);
-
+  let resetTime = calculateNextResetTime(windowMs, precison);
+  
   this.incr = function (key, cb) {
     const currentBucket = buckets[currentBucketIdx];
     if (currentBucket[key]) {
@@ -44,7 +44,7 @@ function MemoryStore(windowMs, precision) {
   };
 
   this.resetBucket = function () {
-    resetTime = calculateNextResetTime(windowMs);
+    resetTime = calculateNextResetTime(windowMs, precison);
     currentBucketIdx = (currentBucketIdx + 1) % buckets.length;
     buckets[currentBucketIdx] = {};
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-rate-limit",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Basic IP rate-limiting middleware for Express. Use to limit repeated requests to public APIs and/or endpoints such as password reset.",
   "homepage": "https://github.com/nfriedly/express-rate-limit",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-rate-limit",
-  "version": "5.4.0",
+  "version": "5.3.0",
   "description": "Basic IP rate-limiting middleware for Express. Use to limit repeated requests to public APIs and/or endpoints such as password reset.",
   "homepage": "https://github.com/nfriedly/express-rate-limit",
   "author": {

--- a/test/memory-store-test.js
+++ b/test/memory-store-test.js
@@ -4,7 +4,7 @@ const MemoryStore = require("../lib/memory-store.js");
 
 describe("MemoryStore store", () => {
   it("sets the value to 1 on first incr", (done) => {
-    const store = new MemoryStore(-1);
+    const store = new MemoryStore(-1, 4);
     const key = "test-store";
 
     store.incr(key, (err, value) => {
@@ -21,7 +21,7 @@ describe("MemoryStore store", () => {
   });
 
   it("increments the key for the store each incr", (done) => {
-    const store = new MemoryStore(-1);
+    const store = new MemoryStore(-1, 4);
     const key = "test-store";
 
     store.incr(key, () => {
@@ -40,7 +40,7 @@ describe("MemoryStore store", () => {
   });
 
   it("resets the key for the store when used with resetKey", (done) => {
-    const store = new MemoryStore(-1);
+    const store = new MemoryStore(-1, 4);
     const key = "test-store";
 
     store.incr(key, () => {
@@ -61,7 +61,7 @@ describe("MemoryStore store", () => {
   });
 
   it("resets all keys for the store when used with resetAll", (done) => {
-    const store = new MemoryStore(-1);
+    const store = new MemoryStore(-1, 4);
     const keyOne = "test-store-one";
     const keyTwo = "test-store-two";
 
@@ -94,7 +94,7 @@ describe("MemoryStore store", () => {
   });
 
   it("resets all keys for the store when the timeout is reached", (done) => {
-    const store = new MemoryStore(50);
+    const store = new MemoryStore(50, 4);
     const keyOne = "test-store-one";
     const keyTwo = "test-store-two";
 
@@ -147,7 +147,7 @@ describe("MemoryStore store", () => {
     });
 
     it("can run in electron where setInterval does not return a Timeout object with an unset function", (done) => {
-      const store = new MemoryStore(-1);
+      const store = new MemoryStore(-1, 4);
       const key = "test-store";
 
       store.incr(key, (err, value) => {
@@ -171,7 +171,7 @@ describe("MemoryStore store", () => {
   });
 
   it("decrements the key for the store each decrement", (done) => {
-    const store = new MemoryStore(-1);
+    const store = new MemoryStore(-1, 4);
     const key = "test-store";
 
     store.incr(key, () => {


### PR DESCRIPTION
Currently it is possible for user/attacker to send `max * 2` requests if they send half of the requests just before `hits` map gets cleared... to mitigate this issue, requests are split into buckets (effectively dividing whole `windowMs` into multiple sub-windows).

Inspired by https://www.figma.com/blog/an-alternative-approach-to-rate-limiting