### PR TITLE
meta: add `main` field to `package.json` and run eslint tests along with import tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,10 @@
 	],
 	"type": "module",
 	"exports": {
-		".": [
-			{
-				"import": "./dist/index.mjs",
-				"require": "./dist/index.cjs"
-			},
-			"./dist/index.cjs"
-		]
+		".": {
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.cjs"
+		}
 	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",

--- a/test/external/imports/js-cjs/package.json
+++ b/test/external/imports/js-cjs/package.json
@@ -4,6 +4,7 @@
 	"description": "A minimal example (JS-CJS) of a project using the express-rate-limit package.",
 	"scripts": {
 		"start": "node source/index.js",
+		"lint": "eslint source/**/*.js",
 		"test": "jest"
 	},
 	"dependencies": {
@@ -11,8 +12,19 @@
 		"express-rate-limit": "file:../../../../express-rate-limit-6.0.3.tgz"
 	},
 	"devDependencies": {
+		"eslint": "^8.6.0",
 		"jest": "^27.4.5",
 		"supertest": "^6.1.6"
+	},
+	"eslintConfig": {
+		"extends": "eslint:recommended",
+		"parserOptions": {
+			"ecmaVersion": 2022
+		},
+		"env": {
+			"es6": true,
+			"node": true
+		}
 	},
 	"jest": {
 		"verbose": true,

--- a/test/external/imports/js-esm/package.json
+++ b/test/external/imports/js-esm/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"start": "node source/index.js",
+		"lint": "eslint source/**/*.js",
 		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
 	},
 	"dependencies": {
@@ -13,8 +14,20 @@
 	},
 	"devDependencies": {
 		"cross-env": "^7.0.3",
+		"eslint": "^8.6.0",
 		"jest": "^27.4.5",
 		"supertest": "^6.1.6"
+	},
+	"eslintConfig": {
+		"extends": "eslint:recommended",
+		"parserOptions": {
+			"ecmaVersion": 2022,
+			"sourceType": "module"
+		},
+		"env": {
+			"es6": true,
+			"node": true
+		}
 	},
 	"jest": {
 		"verbose": true,

--- a/test/external/imports/ts-cjs/package.json
+++ b/test/external/imports/ts-cjs/package.json
@@ -27,12 +27,7 @@
 	},
 	"eslintConfig": {
 		"parser": "@typescript-eslint/parser",
-		"plugins": [
-			"@typescript-eslint"
-		],
 		"extends": [
-			"eslint:recommended",
-			"plugin:@typescript-eslint/eslint-recommended",
 			"plugin:@typescript-eslint/recommended"
 		],
 		"parserOptions": {

--- a/test/external/imports/ts-cjs/package.json
+++ b/test/external/imports/ts-cjs/package.json
@@ -4,6 +4,7 @@
 	"description": "A minimal example (TS-CJS) of a project using the express-rate-limit package.",
 	"scripts": {
 		"start": "ts-node source/index.ts",
+		"lint": "eslint --ext=.ts source/**/*.ts",
 		"test": "jest"
 	},
 	"dependencies": {
@@ -15,11 +16,32 @@
 		"@types/jest": "^27.0.3",
 		"@types/node": "^17.0.4",
 		"@types/supertest": "^2.0.11",
+		"@typescript-eslint/eslint-plugin": "^5.8.1",
+		"@typescript-eslint/parser": "^5.8.1",
+		"eslint": "^8.6.0",
 		"jest": "^27.4.5",
 		"supertest": "^6.1.6",
 		"ts-jest": "^27.1.2",
 		"ts-node": "^10.4.0",
 		"typescript": "^4.5.4"
+	},
+	"eslintConfig": {
+		"parser": "@typescript-eslint/parser",
+		"plugins": [
+			"@typescript-eslint"
+		],
+		"extends": [
+			"eslint:recommended",
+			"plugin:@typescript-eslint/eslint-recommended",
+			"plugin:@typescript-eslint/recommended"
+		],
+		"parserOptions": {
+			"ecmaVersion": 2022
+		},
+		"env": {
+			"es6": true,
+			"node": true
+		}
 	},
 	"jest": {
 		"verbose": true,

--- a/test/external/imports/ts-esm/package.json
+++ b/test/external/imports/ts-esm/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "express-rate-limit-example-ts-cjs",
+	"name": "express-rate-limit-example-ts-esm",
 	"version": "1.0.0",
-	"description": "A minimal example (TS-CJS) of a project using the express-rate-limit package.",
+	"description": "A minimal example (TS-ESM) of a project using the express-rate-limit package.",
 	"type": "module",
 	"scripts": {
 		"start": "node --loader ts-node/esm source/index.ts",

--- a/test/external/imports/ts-esm/package.json
+++ b/test/external/imports/ts-esm/package.json
@@ -29,12 +29,7 @@
 	},
 	"eslintConfig": {
 		"parser": "@typescript-eslint/parser",
-		"plugins": [
-			"@typescript-eslint"
-		],
 		"extends": [
-			"eslint:recommended",
-			"plugin:@typescript-eslint/eslint-recommended",
 			"plugin:@typescript-eslint/recommended"
 		],
 		"parserOptions": {

--- a/test/external/imports/ts-esm/package.json
+++ b/test/external/imports/ts-esm/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"start": "node --loader ts-node/esm source/index.ts",
+		"lint": "eslint --ext=.ts source/**/*.ts",
 		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
 	},
 	"dependencies": {
@@ -16,12 +17,34 @@
 		"@types/jest": "^27.0.3",
 		"@types/node": "^17.0.4",
 		"@types/supertest": "^2.0.11",
+		"@typescript-eslint/eslint-plugin": "^5.8.1",
+		"@typescript-eslint/parser": "^5.8.1",
 		"cross-env": "^7.0.3",
+		"eslint": "^8.6.0",
 		"jest": "^27.4.5",
 		"supertest": "^6.1.6",
 		"ts-jest": "^27.1.2",
 		"ts-node": "^10.4.0",
 		"typescript": "^4.5.4"
+	},
+	"eslintConfig": {
+		"parser": "@typescript-eslint/parser",
+		"plugins": [
+			"@typescript-eslint"
+		],
+		"extends": [
+			"eslint:recommended",
+			"plugin:@typescript-eslint/eslint-recommended",
+			"plugin:@typescript-eslint/recommended"
+		],
+		"parserOptions": {
+			"ecmaVersion": 2022,
+			"sourceType": "module"
+		},
+		"env": {
+			"es6": true,
+			"node": true
+		}
 	},
 	"jest": {
 		"verbose": true,

--- a/test/external/run-all-tests
+++ b/test/external/run-all-tests
@@ -14,6 +14,8 @@ for dir in `ls -d */`; do
 	rm -rf node_modules
 	# Also install the latest version of the package, built off the master branch
 	npm install ../../../../express-rate-limit*.tgz
+	# and ensure the other dependencies are installed...
+	npm install
 	# Run the linter and the tests
 	npm run lint
 	npm run test

--- a/test/external/run-all-tests
+++ b/test/external/run-all-tests
@@ -15,7 +15,8 @@ for dir in `ls -d */`; do
 	# Also install the latest version of the package, built off the master branch
 	npm install ../../../../express-rate-limit*.tgz
 	# Run the linter and the tests
-	npm run lint && npm run test
+	npm run lint
+	npm run test
 	# Go back
 	cd ../
 done

--- a/test/external/run-all-tests
+++ b/test/external/run-all-tests
@@ -14,8 +14,8 @@ for dir in `ls -d */`; do
 	rm -rf node_modules
 	# Also install the latest version of the package, built off the master branch
 	npm install ../../../../express-rate-limit*.tgz
-	# Run the tests
-	npm test
+	# Run the linter and the tests
+	npm run lint && npm run test
 	# Go back
 	cd ../
 done
@@ -44,6 +44,6 @@ npm install ../../../express-rate-limit*.tgz
 # running `npm install <something>`
 npm install
 # Run the tests
-npm test
+npm run test
 # Go back
 cd ../


### PR DESCRIPTION
## Related Issues

- Fixes #277

## What Does This PR Do?

### Tests

- Run `eslint` as part of the import tests too.

### Build

- Add the `main` and `module` fields to `package.json` so ESLint does not complain

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All tests (`npm test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
