### PR TITLE
meta: soft link all external tests to the project folder

### DIFF
--- a/test/external/imports/js-cjs/package.json
+++ b/test/external/imports/js-cjs/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"express": "^4.17.2",
-		"express-rate-limit": "file:../../../../express-rate-limit-6.0.4.tgz"
+		"express-rate-limit": "file:../../../.."
 	},
 	"devDependencies": {
 		"eslint": "^8.6.0",

--- a/test/external/imports/js-esm/package.json
+++ b/test/external/imports/js-esm/package.json
@@ -10,7 +10,7 @@
 	},
 	"dependencies": {
 		"express": "^4.17.2",
-		"express-rate-limit": "file:../../../../express-rate-limit-6.0.4.tgz"
+		"express-rate-limit": "file:../../../.."
 	},
 	"devDependencies": {
 		"cross-env": "^7.0.3",

--- a/test/external/imports/ts-cjs/package.json
+++ b/test/external/imports/ts-cjs/package.json
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"express": "^4.17.2",
-		"express-rate-limit": "file:../../../../express-rate-limit-6.0.4.tgz"
+		"express-rate-limit": "file:../../../.."
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",

--- a/test/external/imports/ts-esm/package.json
+++ b/test/external/imports/ts-esm/package.json
@@ -10,7 +10,7 @@
 	},
 	"dependencies": {
 		"express": "^4.17.2",
-		"express-rate-limit": "file:../../../../express-rate-limit-6.0.4.tgz"
+		"express-rate-limit": "file:../../../.."
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",

--- a/test/external/run-all-tests
+++ b/test/external/run-all-tests
@@ -12,9 +12,6 @@ for dir in `ls -d */`; do
 	cd $dir
 	# Get a fresh install of all node modules
 	rm -rf node_modules
-	# Also install the latest version of the package, built off the master branch
-	npm install ../../../../express-rate-limit*.tgz
-	# and ensure the other dependencies are installed...
 	npm install
 	# Run the linter and the tests
 	npm run lint
@@ -41,10 +38,6 @@ if [[ -z "$CI" ]]; then
 fi
 # Get a fresh install of all the node modules
 rm -rf node_modules
-# Also install the latest version of the package, built off the master branch
-npm install ../../../express-rate-limit*.tgz
-# npm 6 does not install other packages if they are not installed already when
-# running `npm install <something>`
 npm install
 # Run the tests
 npm run test

--- a/test/external/stores/package.json
+++ b/test/external/stores/package.json
@@ -9,7 +9,7 @@
 	"dependencies": {
 		"@types/rate-limit-redis": "^1.7.3",
 		"express": "^4.17.2",
-		"express-rate-limit": "file:../../../express-rate-limit-6.0.4.tgz",
+		"express-rate-limit": "file:../../..",
 		"precise-memory-rate-limit": "^1.1.4",
 		"rate-limit-memcached": "^0.6.0",
 		"rate-limit-mongo": "^2.3.2",


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/nfriedly/express-rate-limit/pull/282#discussion_r779520826

## What Does This PR Do?

### Changed

- Instead of building a `.tgz` file and installing it in all external tests, install the project folder directly in the external tests.

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All tests (`npm test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
