### PR TITLE
fix: remove --footer option from esbuild to fix "default is not a function" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 	},
 	"scripts": {
 		"clean": "del-cli dist/ coverage/ *.log *.tmp *.bak *.tgz",
-		"build:cjs": "esbuild --bundle --format=cjs --outfile=dist/index.cjs --footer:js=\"module.exports = rateLimit;\" source/index.ts",
+		"build:cjs": "esbuild --bundle --format=cjs --outfile=dist/index.cjs source/index.ts",
 		"build:esm": "esbuild --bundle --format=esm --outfile=dist/index.mjs source/index.ts",
 		"build:types": "dts-bundle-generator --out-file=dist/index.d.ts source/index.ts",
 		"compile": "run-s clean build:*",


### PR DESCRIPTION
Fixes #280 