### PR TITLE
fix: deprecate `onLimitReached`, reword documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@jest/globals": "^27.4.6",
 				"@types/express": "^4.17.13",
 				"@types/jest": "^27.4.0",
-				"@types/node": "^16.11.19",
+				"@types/node": "^16.11.20",
 				"@types/supertest": "^2.0.11",
 				"cross-env": "^7.0.3",
 				"del-cli": "^4.0.1",
@@ -24,7 +24,7 @@
 				"lint-staged": "^12.1.7",
 				"npm-run-all": "^4.1.5",
 				"supertest": "^6.2.1",
-				"ts-jest": "^27.1.1",
+				"ts-jest": "^27.1.3",
 				"ts-node": "^10.4.0",
 				"typescript": "^4.5.2",
 				"xo": "^0.47.0"
@@ -1387,9 +1387,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.11.19",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
-			"integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng==",
+			"version": "16.11.20",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.20.tgz",
+			"integrity": "sha512-lAKaZ0Lc1Umwd0AqLr6iy5U8u/1DpK7/JzNgQn9cMMUk2mFR8bbhEP8BQrI9Cm5CU0bOVCaWbkGBvgqKMOJHsw==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -9419,9 +9419,9 @@
 			}
 		},
 		"node_modules/ts-jest": {
-			"version": "27.1.2",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.2.tgz",
-			"integrity": "sha512-eSOiJOWq6Hhs6Khzk5wKC5sgWIXgXqOCiIl1+3lfnearu58Hj4QpE5tUhQcA3xtZrELbcvAGCsd6HB8OsaVaTA==",
+			"version": "27.1.3",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.3.tgz",
+			"integrity": "sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==",
 			"dev": true,
 			"dependencies": {
 				"bs-logger": "0.x",
@@ -12106,9 +12106,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.11.19",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
-			"integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng==",
+			"version": "16.11.20",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.20.tgz",
+			"integrity": "sha512-lAKaZ0Lc1Umwd0AqLr6iy5U8u/1DpK7/JzNgQn9cMMUk2mFR8bbhEP8BQrI9Cm5CU0bOVCaWbkGBvgqKMOJHsw==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -18077,9 +18077,9 @@
 			"dev": true
 		},
 		"ts-jest": {
-			"version": "27.1.2",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.2.tgz",
-			"integrity": "sha512-eSOiJOWq6Hhs6Khzk5wKC5sgWIXgXqOCiIl1+3lfnearu58Hj4QpE5tUhQcA3xtZrELbcvAGCsd6HB8OsaVaTA==",
+			"version": "27.1.3",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.3.tgz",
+			"integrity": "sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==",
 			"dev": true,
 			"requires": {
 				"bs-logger": "0.x",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"@jest/globals": "^27.4.6",
 		"@types/express": "^4.17.13",
 		"@types/jest": "^27.4.0",
-		"@types/node": "^16.11.19",
+		"@types/node": "^16.11.20",
 		"@types/supertest": "^2.0.11",
 		"cross-env": "^7.0.3",
 		"del-cli": "^4.0.1",
@@ -85,7 +85,7 @@
 		"lint-staged": "^12.1.7",
 		"npm-run-all": "^4.1.5",
 		"supertest": "^6.2.1",
-		"ts-jest": "^27.1.1",
+		"ts-jest": "^27.1.3",
 		"ts-node": "^10.4.0",
 		"typescript": "^4.5.2",
 		"xo": "^0.47.0"

--- a/readme.md
+++ b/readme.md
@@ -433,7 +433,9 @@ Here is a list of external stores:
 | [`rate-limit-mongo`](https://www.npmjs.com/package/rate-limit-mongo)                   | A [MongoDB](https://www.mongodb.com/)-backed store.                                                   | Legacy              |
 | [`precise-memory-rate-limit`](https://www.npmjs.com/package/precise-memory-rate-limit) | A memory store similar to the built-in one, except that it stores a distinct timestamp for each key.  | Legacy              |
 
-Take a look at [this guide]() if you wish to create your own store.
+Take a look at
+[this guide](https://github.com/nfriedly/express-rate-limit/wiki/Creating-Your-Own-Store)
+if you wish to create your own store.
 
 ## Request API
 

--- a/readme.md
+++ b/readme.md
@@ -258,8 +258,10 @@ Defaults to `429` (HTTP 429 Too Many Requests - RFC 6585).
 > `boolean`
 
 Whether to send the legacy rate limit headers for the limit
-(`X-RateLimit-Limit`), current usage (`X-RateLimit-Remaining`) and time to wait
-before retrying (`Retry-After`) on all responses.
+(`X-RateLimit-Limit`), current usage (`X-RateLimit-Remaining`) and reset time
+(if the store provides it) (`X-RateLimit-Reset`) on all responses. If set to
+`true`, the middleware also sends the `Retry-After` header on all blocked
+requests.
 
 Defaults to `true` (for backward compatibility).
 
@@ -272,8 +274,9 @@ Defaults to `true` (for backward compatibility).
 Whether to enable support for headers conforming to the
 [ratelimit standardization draft](https://github.com/ietf-wg-httpapi/ratelimit-headers/blob/main/draft-ietf-httpapi-ratelimit-headers.md)
 adopted by the IETF (`RateLimit-Limit`, `RateLimit-Remaining`, and, if the store
-supports it, `RateLimit-Reset`). May be used in conjunction with, or instead of
-the `legacyHeaders` option.
+supports it, `RateLimit-Reset`). If set to `true`, the middleware also sends the
+`Retry-After` header on all blocked requests. May be used in conjunction with,
+or instead of the `legacyHeaders` option.
 
 Defaults to `false` (for backward compatibility, but its use is recommended).
 

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -16,9 +16,9 @@ import {
 /**
  * Type guard to check if a store is legacy store.
  *
- * @param store {LegacyStore | Store} - The store to check
+ * @param store {LegacyStore | Store} - The store to check.
  *
- * @return {boolean} - Whether the store is a legacy store
+ * @return {boolean} - Whether the store is a legacy store.
  */
 const isLegacyStore = (store: LegacyStore | Store): store is LegacyStore =>
 	// Check that `incr` exists but `increment` does not - store authors might want
@@ -29,9 +29,9 @@ const isLegacyStore = (store: LegacyStore | Store): store is LegacyStore =>
 /**
  * Converts a legacy store to the promisified version.
  *
- * @param store {LegacyStore | Store} - The legacy store or even a modern store
+ * @param store {LegacyStore | Store} - The store passed to the middleware.
  *
- * @returns {Store} - The promisified version of the store
+ * @returns {Store} - The promisified version of the store.
  */
 const promisifyStore = (passedStore: LegacyStore | Store): Store => {
 	if (!isLegacyStore(passedStore)) {
@@ -39,7 +39,6 @@ const promisifyStore = (passedStore: LegacyStore | Store): Store => {
 		return passedStore
 	}
 
-	// Why can't Typescript understand this?
 	const legacyStore = passedStore
 
 	// A promisified version of the store
@@ -78,19 +77,19 @@ const promisifyStore = (passedStore: LegacyStore | Store): Store => {
 }
 
 /**
- * Adds the defaults for options the user has not specified.
+ * Type-checks and adds the defaults for options the user has not specified.
  *
- * @param options {Options} - The options the user specifies
+ * @param options {Options} - The options the user specifies.
  *
- * @returns {Options} - A complete configuration object
+ * @returns {Options} - A complete configuration object.
  */
 const parseOptions = (
 	passedOptions: Omit<Partial<Options>, 'store'> & {
 		store?: Store | LegacyStore
 	},
 ): Options => {
-	// Now add the defaults for the other options
-
+	// See ./types.ts#Options for a detailed description of the options and their
+	// defaults.
 	const options = {
 		windowMs: 60 * 1000,
 		store: new MemoryStore(),
@@ -127,6 +126,7 @@ const parseOptions = (
 			_response: Response,
 			_optionsUsed: Options,
 		): void => {},
+		// Allow the above to be overriden by the options passed to the middleware
 		...passedOptions,
 	}
 
@@ -158,9 +158,9 @@ const parseOptions = (
  * Just pass on any errors for the developer to handle, usually as a HTTP 500
  * Internal Server Error.
  *
- * @param fn {RequestHandler} - The request handler for which to handle errors
+ * @param fn {RequestHandler} - The request handler for which to handle errors.
  *
- * @returns {RequestHandler} - The request handler wrapped with a `.catch` clause
+ * @returns {RequestHandler} - The request handler wrapped with a `.catch` clause.
  *
  * @private
  */
@@ -178,9 +178,9 @@ const handleAsyncErrors =
  *
  * Create an instance of IP rate-limiting middleware for Express.
  *
- * @param passedOptions {Options} - Options to configure the rate limiter
+ * @param passedOptions {Options} - Options to configure the rate limiter.
  *
- * @returns {RateLimitRequestHandler} - The middleware that rate-limits clients based on your configuration
+ * @returns {RateLimitRequestHandler} - The middleware that rate-limits clients based on your configuration.
  *
  * @public
  */
@@ -294,14 +294,15 @@ const rateLimit = (
 				}
 			}
 
-			// Call the {@link Options.onLimitReached} callback on
-			// the first request where client exceeds their rate limit.
+			// Call the `onLimitReached` callback on the first request where client
+			// exceeds their rate limit
+			// NOTE: `onLimitReached` is deprecated, this should be removed in v7.x
 			if (maxHits && totalHits === maxHits + 1) {
 				options.onLimitReached(request, response, options)
 			}
 
-			// If the client has exceeded their rate limit, set the Retry-After
-			// header and call the {@link Options.handler} function
+			// If the client has exceeded their rate limit, set the Retry-After header
+			// and call the `handler` function
 			if (maxHits && totalHits > maxHits) {
 				if (
 					(options.legacyHeaders || options.standardHeaders) &&

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -6,7 +6,7 @@ import { Store, Options, IncrementResponse } from './types.js'
 /**
  * Calculates the time when all hit counters will be reset.
  *
- * @param windowMs {number} - The duration of a window (in milliseconds)
+ * @param windowMs {number} - The duration of a window (in milliseconds).
  *
  * @returns {Date}
  *
@@ -19,8 +19,7 @@ const calculateNextResetTime = (windowMs: number): Date => {
 }
 
 /**
- * A {@link Store} that stores the hit count for each client in
- * memory.
+ * A `Store` that stores the hit count for each client in memory.
  *
  * @public
  */
@@ -45,7 +44,7 @@ export default class MemoryStore implements Store {
 	/**
 	 * Method that initializes the store.
 	 *
-	 * @param options {Options} - The options used to setup the middleware
+	 * @param options {Options} - The options used to setup the middleware.
 	 */
 	init(options: Options): void {
 		// Get the duration of a window from the options
@@ -69,9 +68,9 @@ export default class MemoryStore implements Store {
 	/**
 	 * Method to increment a client's hit counter.
 	 *
-	 * @param key {string} - The identifier for a client
+	 * @param key {string} - The identifier for a client.
 	 *
-	 * @returns {IncrementResponse} - The number of hits and reset time for that client
+	 * @returns {IncrementResponse} - The number of hits and reset time for that client.
 	 *
 	 * @public
 	 */
@@ -88,7 +87,7 @@ export default class MemoryStore implements Store {
 	/**
 	 * Method to decrement a client's hit counter.
 	 *
-	 * @param key {string} - The identifier for a client
+	 * @param key {string} - The identifier for a client.
 	 *
 	 * @public
 	 */
@@ -102,7 +101,7 @@ export default class MemoryStore implements Store {
 	/**
 	 * Method to reset a client's hit counter.
 	 *
-	 * @param key {string} - The identifier for a client
+	 * @param key {string} - The identifier for a client.
 	 *
 	 * @public
 	 */

--- a/source/types.ts
+++ b/source/types.ts
@@ -6,9 +6,9 @@ import { Request, Response, NextFunction, RequestHandler } from 'express'
 /**
  * Callback that fires when a client's hit counter is incremented.
  *
- * @param error {Error | undefined} - The error that occurred, if any
- * @param totalHits {number} - The number of hits for that client so far
- * @param resetTime {Date | undefined} - The time when the counter resets
+ * @param error {Error | undefined} - The error that occurred, if any.
+ * @param totalHits {number} - The number of hits for that client so far.
+ * @param resetTime {Date | undefined} - The time when the counter resets.
  */
 export type IncrementCallback = (
 	error: Error | undefined,
@@ -18,12 +18,12 @@ export type IncrementCallback = (
 
 /**
  * Method (in the form of middleware) to generate/retrieve a value based on the
- * incoming request
+ * incoming request.
  *
- * @param request {Request} - The Express request object
- * @param response {Response} - The Express response object
+ * @param request {Request} - The Express request object.
+ * @param response {Response} - The Express response object.
  *
- * @returns {T} - The value needed
+ * @returns {T} - The value needed.
  */
 export type ValueDeterminingMiddleware<T> = (
 	request: Request,
@@ -34,10 +34,10 @@ export type ValueDeterminingMiddleware<T> = (
  * Express request handler that sends back a response when a client is
  * rate-limited.
  *
- * @param request {Request} - The Express request object
- * @param response {Response} - The Express response object
- * @param next {NextFunction} - The Express `next` function, can be called to skip responding
- * @param optionsUsed {Options} - The options used to set up the middleware
+ * @param request {Request} - The Express request object.
+ * @param response {Response} - The Express response object.
+ * @param next {NextFunction} - The Express `next` function, can be called to skip responding.
+ * @param optionsUsed {Options} - The options used to set up the middleware.
  */
 export type RateLimitExceededEventHandler = (
 	request: Request,
@@ -51,9 +51,9 @@ export type RateLimitExceededEventHandler = (
  * but not for subsequent requests. May be used for logging, etc. Should *not*
  * send a response.
  *
- * @param request {Request} - The Express request object
- * @param response {Response} - The Express response object
- * @param optionsUsed {Options} - The options used to set up the middleware
+ * @param request {Request} - The Express request object.
+ * @param response {Response} - The Express response object.
+ * @param optionsUsed {Options} - The options used to set up the middleware.
  */
 export type RateLimitReachedEventHandler = (
 	request: Request,
@@ -64,8 +64,8 @@ export type RateLimitReachedEventHandler = (
 /**
  * Data returned from the `Store` when a client's hit counter is incremented.
  *
- * @property totalHits {number} - The number of hits for that client so far
- * @property resetTime {Date | undefined} - The time when the counter resets
+ * @property totalHits {number} - The number of hits for that client so far.
+ * @property resetTime {Date | undefined} - The time when the counter resets.
  */
 export type IncrementResponse = {
 	totalHits: number
@@ -79,7 +79,7 @@ export type RateLimitRequestHandler = RequestHandler & {
 	/**
 	 * Method to reset a client's hit counter.
 	 *
-	 * @param key {string} - The identifier for a client
+	 * @param key {string} - The identifier for a client.
 	 */
 	resetKey: (key: string) => void
 }
@@ -93,22 +93,22 @@ export interface LegacyStore {
 	/**
 	 * Method to increment a client's hit counter.
 	 *
-	 * @param key {string} - The identifier for a client
-	 * @param callback {IncrementCallback} - The callback to call once the counter is incremented
+	 * @param key {string} - The identifier for a client.
+	 * @param callback {IncrementCallback} - The callback to call once the counter is incremented.
 	 */
 	incr: (key: string, callback: IncrementCallback) => void
 
 	/**
 	 * Method to decrement a client's hit counter.
 	 *
-	 * @param key {string} - The identifier for a client
+	 * @param key {string} - The identifier for a client.
 	 */
 	decrement: (key: string) => void
 
 	/**
 	 * Method to reset a client's hit counter.
 	 *
-	 * @param key {string} - The identifier for a client
+	 * @param key {string} - The identifier for a client.
 	 */
 	resetKey: (key: string) => void
 
@@ -126,30 +126,30 @@ export interface Store {
 	 * Method that initializes the store, and has access to the options passed to
 	 * the middleware too.
 	 *
-	 * @param options {Options} - The options used to setup the middleware
+	 * @param options {Options} - The options used to setup the middleware.
 	 */
 	init?: (options: Options) => void
 
 	/**
 	 * Method to increment a client's hit counter.
 	 *
-	 * @param key {string} - The identifier for a client
+	 * @param key {string} - The identifier for a client.
 	 *
-	 * @returns {IncrementResponse} - The number of hits and reset time for that client
+	 * @returns {IncrementResponse} - The number of hits and reset time for that client.
 	 */
 	increment: (key: string) => Promise<IncrementResponse> | IncrementResponse
 
 	/**
 	 * Method to decrement a client's hit counter.
 	 *
-	 * @param key {string} - The identifier for a client
+	 * @param key {string} - The identifier for a client.
 	 */
 	decrement: (key: string) => Promise<void> | void
 
 	/**
 	 * Method to reset a client's hit counter.
 	 *
-	 * @param key {string} - The identifier for a client
+	 * @param key {string} - The identifier for a client.
 	 */
 	resetKey: (key: string) => Promise<void> | void
 
@@ -165,20 +165,26 @@ export interface Store {
 export interface Options {
 	/**
 	 * How long we should remember the requests.
+	 *
+	 * Defaults to `60000` ms (= 1 minute).
 	 */
 	readonly windowMs: number
 
 	/**
-	 * The maximum number of connection to allow during the `window` before
+	 * The maximum number of connections to allow during the `window` before
 	 * rate limiting the client.
 	 *
 	 * Can be the limit itself as a number or express middleware that parses
 	 * the request and then figures out the limit.
+	 *
+	 * Defaults to `5`.
 	 */
 	readonly max: number | ValueDeterminingMiddleware<number>
 
 	/**
 	 * The response body to send back when a client is rate limited.
+	 *
+	 * Defaults to `'Too many requests, please try again later.'`
 	 */
 	readonly message: any
 
@@ -192,11 +198,15 @@ export interface Options {
 	/**
 	 * Whether to send `X-RateLimit-*` headers with the rate limit and the number
 	 * of requests.
+	 *
+	 * Defaults to `true` (for backward compatibility).
 	 */
 	readonly legacyHeaders: boolean
 
 	/**
-	 * Whether to enable support for the rate limit standardization headers (`RateLimit-*`).
+	 * Whether to enable support for the standardized rate limit headers (`RateLimit-*`).
+	 *
+	 * Defaults to `false` (for backward compatibility, but its use is recommended).
 	 */
 	readonly standardHeaders: boolean
 
@@ -210,20 +220,18 @@ export interface Options {
 	/**
 	 * If `true`, the library will (by default) skip all requests that have a 4XX
 	 * or 5XX status.
+	 *
+	 * Defaults to `false`.
 	 */
 	readonly skipFailedRequests: boolean
 
 	/**
 	 * If `true`, the library will (by default) skip all requests that have a
 	 * status code less than 400.
+	 *
+	 * Defaults to `false`.
 	 */
 	readonly skipSuccessfulRequests: boolean
-
-	/**
-	 * Method to determine whether or not the request counts as 'succesful'. Used
-	 * when either `skipSuccessfulRequests` or `skipFailedRequests` is set to true.
-	 */
-	readonly requestWasSuccessful: ValueDeterminingMiddleware<boolean>
 
 	/**
 	 * Method to generate custom identifiers for clients.
@@ -233,25 +241,43 @@ export interface Options {
 	readonly keyGenerator: ValueDeterminingMiddleware<string>
 
 	/**
-	 * Method (in the form of middleware) to determine whether or not this request
-	 * counts towards a client's quota.
-	 */
-	readonly skip: ValueDeterminingMiddleware<boolean>
-
-	/**
 	 * Express request handler that sends back a response when a client is
 	 * rate-limited.
+	 *
+	 * By default, sends back the `statusCode` and `message` set via the options.
 	 */
 	readonly handler: RateLimitExceededEventHandler
 
 	/**
 	 * Express request handler that sends back a response when a client has
 	 * reached their rate limit, and will be rate limited on their next request.
+	 *
+	 * @deprecated 6.x - Please use a custom `handler` that checks the number of
+	 * hits instead.
 	 */
 	readonly onLimitReached: RateLimitReachedEventHandler
 
 	/**
-	 * The {@link Store} to use to store the hit count for each client.
+	 * Method (in the form of middleware) to determine whether or not this request
+	 * counts towards a client's quota.
+	 *
+	 * By default, skips no requests.
+	 */
+	readonly skip: ValueDeterminingMiddleware<boolean>
+
+	/**
+	 * Method to determine whether or not the request counts as 'succesful'. Used
+	 * when either `skipSuccessfulRequests` or `skipFailedRequests` is set to true.
+	 *
+	 * By default, requests with a response status code less than 400 are considered
+	 * successful.
+	 */
+	readonly requestWasSuccessful: ValueDeterminingMiddleware<boolean>
+
+	/**
+	 * The `Store` to use to store the hit count for each client.
+	 *
+	 * By default, the built-in `MemoryStore` will be used.
 	 */
 	store: Store
 


### PR DESCRIPTION
## Related Issues

- Fixes #287

## What Does This PR Do?

### Changed

- Deprecates `onLimitReached`, as v6.0.0 was supposed to do.
- Bumps development dependencies (minor/patch changes only).
- Fixes inconsistencies between the readme and `source/types.ts`.

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All tests (`npm test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
