### PR TITLE
fix: use default value for option when `undefined` is passed

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -142,8 +142,7 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 		store: promisifyStore(notUndefinedOptions.store ?? new MemoryStore()),
 	}
 
-	// Ensure that the store passed implements the either the `Store` or `LegacyStore`
-	// interface
+	// Ensure that the store passed implements the `Store` interface
 	if (
 		typeof config.store.increment !== 'function' ||
 		typeof config.store.decrement !== 'function' ||

--- a/source/types.ts
+++ b/source/types.ts
@@ -279,7 +279,7 @@ export interface Options {
 	 *
 	 * By default, the built-in `MemoryStore` will be used.
 	 */
-	store: Store
+	store: Store | LegacyStore
 
 	/**
 	 * Whether to send `X-RateLimit-*` headers with the rate limit and the number


### PR DESCRIPTION
<!--
	Hi there! Thanks for contributing! Please fill in this template to help us
	review and merge the PR as quickly and easily as possible!
-->

## Related Issues

Closes #290

<!--
	If this is a bug fix, or adds a feature mentioned in another issue, mention
	it as follows:

	- Closes #10
	- Fixes #15
-->

## What Does This PR Do?

This PR changes how options are merged with the defaults. At the moment, passing
```js
{ windowMs: undefined }
```

as an option, will result in `windowMs` being set to undefined, rather than falling back to the default of `60000ms`. This is a bit counterintuitive, as most APIs in JS do not differentiate between a property not existing and a property being undefined. This is a consequence of the spread operator being used, though.

<!--
	Explain what has been added/changed/removed, in
	[keepachangelog.com](https://keepachangelog.com) style.
-->

### Added

Added a new private function that omits the options, and is called inside `parseOptions`.

<!--
	- Added a new method on the limiter object to reset the count for a certain IP [#10]
-->

## Caveats/Problems/Issues

TypeScript **really** sucks at dealing with object mutation like this. I have had to add a `@ts-expect-error` and `eslint-disable-next-line` inside the function that mutates the object. I spent about 15 minutes trying to come up with a neater way to mutate the object that didn't require this, but I couldn't figure it out.

I ran `autofix`, so that should make this code fit in with the repo a bit better.q

<!--
	Any weird code/problems you faced while making this PR. Feel free to ask for
	help with anything, especially if it's your first time contributing!
-->

## Checklist

- [X] The issues that this PR fixes/closes have been mentioned above.
- [X] What this PR adds/changes/removes has been explained.
- [X] All tests (`npm test`) pass.
- [X] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [X] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
