### PR TITLE
meta: add express 5 as peer dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,19 +52,6 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
-    services:
-      rate-limit-redis:
-        image: redis
-        ports:
-          - 6379:6379
-      rate-limit-mongo:
-        image: mongo
-        ports:
-          - 27017:27017
-      rate-limit-memcached:
-        image: memcached
-        ports:
-          - 11211:11211
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1829,9 +1829,9 @@
 			"dev": true
 		},
 		"node_modules/array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+			"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
 			"dev": true
 		},
 		"node_modules/array-includes": {
@@ -2025,7 +2025,7 @@
 				"type-is": "~1.6.18"
 			},
 			"engines": {
-				"node": ">= 0.8"
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -4591,7 +4591,7 @@
 				"content-type": "~1.0.4",
 				"cookie": "0.4.2",
 				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
+				"debug": "3.1.0",
 				"depd": "~1.1.2",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
@@ -4600,15 +4600,17 @@
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
 				"methods": "~1.1.2",
+				"mime-types": "~2.1.34",
 				"on-finished": "~2.3.0",
 				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
+				"path-is-absolute": "1.0.1",
 				"proxy-addr": "~2.0.7",
 				"qs": "6.9.7",
 				"range-parser": "~1.2.1",
+				"router": "2.0.0-beta.1",
 				"safe-buffer": "5.2.1",
-				"send": "0.17.2",
-				"serve-static": "1.14.2",
+				"send": "1.0.0-beta.1",
+				"serve-static": "2.0.0-beta.1",
 				"setprototypeof": "1.2.0",
 				"statuses": "~1.5.0",
 				"type-is": "~1.6.18",
@@ -4616,7 +4618,16 @@
 				"vary": "~1.1.2"
 			},
 			"engines": {
-				"node": ">= 0.10.0"
+				"node": ">= 4"
+			}
+		},
+		"node_modules/express/node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -7283,18 +7294,6 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"dev": true,
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/mime-db": {
 			"version": "1.51.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -7916,9 +7915,9 @@
 			"dev": true
 		},
 		"node_modules/path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
+			"integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
 			"dev": true
 		},
 		"node_modules/path-type": {
@@ -8549,6 +8548,23 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/router": {
+			"version": "2.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.0.0-beta.1.tgz",
+			"integrity": "sha512-GLoYgkhAGAiwVda5nt6Qd4+5RAPuQ4WIYLlZ+mxfYICI+22gnIB3eCfmhgV8+uJNPS1/39DOYi/vdrrz0/ouKA==",
+			"dev": true,
+			"dependencies": {
+				"array-flatten": "3.0.0",
+				"methods": "~1.1.2",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "3.2.0",
+				"setprototypeof": "1.2.0",
+				"utils-merge": "1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8657,28 +8673,42 @@
 			}
 		},
 		"node_modules/send": {
-			"version": "0.17.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-			"integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+			"version": "1.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.0.0-beta.1.tgz",
+			"integrity": "sha512-OKTRokcl/oo34O8+6aUpj8Jf2Bjw2D0tZzmX0/RvyfVC9ZOZW+HPAWAlhS817IsRaCnzYX1z++h2kHFr2/KNRg==",
 			"dev": true,
 			"dependencies": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
+				"debug": "3.1.0",
 				"destroy": "~1.0.4",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
 				"http-errors": "1.8.1",
-				"mime": "1.6.0",
+				"mime-types": "~2.1.34",
 				"ms": "2.1.3",
 				"on-finished": "~2.3.0",
 				"range-parser": "~1.2.1",
 				"statuses": "~1.5.0"
 			},
 			"engines": {
-				"node": ">= 0.8.0"
+				"node": ">= 0.10"
 			}
+		},
+		"node_modules/send/node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/send/node_modules/debug/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"node_modules/send/node_modules/ms": {
 			"version": "2.1.3",
@@ -8697,18 +8727,18 @@
 			}
 		},
 		"node_modules/serve-static": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-			"integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+			"version": "2.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.0.0-beta.1.tgz",
+			"integrity": "sha512-DEJ9on/tQeFO2Omj7ovT02lCp1YgP4Kb8W2lv2o/4keTFAbgc8HtH3yPd47++2wv9lvQeqiA7FHFDe5+8c4XpA==",
 			"dev": true,
 			"dependencies": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
-				"send": "0.17.2"
+				"send": "1.0.0-beta.1"
 			},
 			"engines": {
-				"node": ">= 0.8.0"
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/setprototypeof": {
@@ -12548,9 +12578,9 @@
 			"dev": true
 		},
 		"array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+			"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
 			"dev": true
 		},
 		"array-includes": {
@@ -14529,7 +14559,7 @@
 				"content-type": "~1.0.4",
 				"cookie": "0.4.2",
 				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
+				"debug": "3.1.0",
 				"depd": "~1.1.2",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
@@ -14538,20 +14568,33 @@
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
 				"methods": "~1.1.2",
+				"mime-types": "~2.1.34",
 				"on-finished": "~2.3.0",
 				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
+				"path-is-absolute": "1.0.1",
 				"proxy-addr": "~2.0.7",
 				"qs": "6.9.7",
 				"range-parser": "~1.2.1",
+				"router": "2.0.0-beta.1",
 				"safe-buffer": "5.2.1",
-				"send": "0.17.2",
-				"serve-static": "1.14.2",
+				"send": "1.0.0-beta.1",
+				"serve-static": "2.0.0-beta.1",
 				"setprototypeof": "1.2.0",
 				"statuses": "~1.5.0",
 				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
 			}
 		},
 		"fast-deep-equal": {
@@ -16532,12 +16575,6 @@
 				"picomatch": "^2.2.3"
 			}
 		},
-		"mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"dev": true
-		},
 		"mime-db": {
 			"version": "1.51.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -17004,9 +17041,9 @@
 			"dev": true
 		},
 		"path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
+			"integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
 			"dev": true
 		},
 		"path-type": {
@@ -17435,6 +17472,20 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"router": {
+			"version": "2.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.0.0-beta.1.tgz",
+			"integrity": "sha512-GLoYgkhAGAiwVda5nt6Qd4+5RAPuQ4WIYLlZ+mxfYICI+22gnIB3eCfmhgV8+uJNPS1/39DOYi/vdrrz0/ouKA==",
+			"dev": true,
+			"requires": {
+				"array-flatten": "3.0.0",
+				"methods": "~1.1.2",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "3.2.0",
+				"setprototypeof": "1.2.0",
+				"utils-merge": "1.0.1"
+			}
+		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -17502,26 +17553,42 @@
 			"dev": true
 		},
 		"send": {
-			"version": "0.17.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-			"integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+			"version": "1.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.0.0-beta.1.tgz",
+			"integrity": "sha512-OKTRokcl/oo34O8+6aUpj8Jf2Bjw2D0tZzmX0/RvyfVC9ZOZW+HPAWAlhS817IsRaCnzYX1z++h2kHFr2/KNRg==",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
+				"debug": "3.1.0",
 				"destroy": "~1.0.4",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
 				"http-errors": "1.8.1",
-				"mime": "1.6.0",
+				"mime-types": "~2.1.34",
 				"ms": "2.1.3",
 				"on-finished": "~2.3.0",
 				"range-parser": "~1.2.1",
 				"statuses": "~1.5.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						}
+					}
+				},
 				"ms": {
 					"version": "2.1.3",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -17541,15 +17608,15 @@
 			}
 		},
 		"serve-static": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-			"integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+			"version": "2.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.0.0-beta.1.tgz",
+			"integrity": "sha512-DEJ9on/tQeFO2Omj7ovT02lCp1YgP4Kb8W2lv2o/4keTFAbgc8HtH3yPd47++2wv9lvQeqiA7FHFDe5+8c4XpA==",
 			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
-				"send": "0.17.2"
+				"send": "1.0.0-beta.1"
 			}
 		},
 		"setprototypeof": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"node": ">= 12.9.0"
 			},
 			"peerDependencies": {
-				"express": "^4"
+				"express": "^4 || ^5"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1829,9 +1829,9 @@
 			"dev": true
 		},
 		"node_modules/array-flatten": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-			"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
 			"dev": true
 		},
 		"node_modules/array-includes": {
@@ -2025,7 +2025,7 @@
 				"type-is": "~1.6.18"
 			},
 			"engines": {
-				"node": ">= 0.10"
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -4591,7 +4591,7 @@
 				"content-type": "~1.0.4",
 				"cookie": "0.4.2",
 				"cookie-signature": "1.0.6",
-				"debug": "3.1.0",
+				"debug": "2.6.9",
 				"depd": "~1.1.2",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
@@ -4600,17 +4600,15 @@
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
 				"methods": "~1.1.2",
-				"mime-types": "~2.1.34",
 				"on-finished": "~2.3.0",
 				"parseurl": "~1.3.3",
-				"path-is-absolute": "1.0.1",
+				"path-to-regexp": "0.1.7",
 				"proxy-addr": "~2.0.7",
 				"qs": "6.9.7",
 				"range-parser": "~1.2.1",
-				"router": "2.0.0-beta.1",
 				"safe-buffer": "5.2.1",
-				"send": "1.0.0-beta.1",
-				"serve-static": "2.0.0-beta.1",
+				"send": "0.17.2",
+				"serve-static": "1.14.2",
 				"setprototypeof": "1.2.0",
 				"statuses": "~1.5.0",
 				"type-is": "~1.6.18",
@@ -4618,16 +4616,7 @@
 				"vary": "~1.1.2"
 			},
 			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/express/node_modules/debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
+				"node": ">= 0.10.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -7294,6 +7283,18 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true,
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/mime-db": {
 			"version": "1.51.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -7915,9 +7916,9 @@
 			"dev": true
 		},
 		"node_modules/path-to-regexp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
-			"integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
 			"dev": true
 		},
 		"node_modules/path-type": {
@@ -8548,23 +8549,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/router": {
-			"version": "2.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/router/-/router-2.0.0-beta.1.tgz",
-			"integrity": "sha512-GLoYgkhAGAiwVda5nt6Qd4+5RAPuQ4WIYLlZ+mxfYICI+22gnIB3eCfmhgV8+uJNPS1/39DOYi/vdrrz0/ouKA==",
-			"dev": true,
-			"dependencies": {
-				"array-flatten": "3.0.0",
-				"methods": "~1.1.2",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "3.2.0",
-				"setprototypeof": "1.2.0",
-				"utils-merge": "1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8673,42 +8657,28 @@
 			}
 		},
 		"node_modules/send": {
-			"version": "1.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-1.0.0-beta.1.tgz",
-			"integrity": "sha512-OKTRokcl/oo34O8+6aUpj8Jf2Bjw2D0tZzmX0/RvyfVC9ZOZW+HPAWAlhS817IsRaCnzYX1z++h2kHFr2/KNRg==",
+			"version": "0.17.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+			"integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
 			"dev": true,
 			"dependencies": {
-				"debug": "3.1.0",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
 				"destroy": "~1.0.4",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
 				"http-errors": "1.8.1",
-				"mime-types": "~2.1.34",
+				"mime": "1.6.0",
 				"ms": "2.1.3",
 				"on-finished": "~2.3.0",
 				"range-parser": "~1.2.1",
 				"statuses": "~1.5.0"
 			},
 			"engines": {
-				"node": ">= 0.10"
+				"node": ">= 0.8.0"
 			}
-		},
-		"node_modules/send/node_modules/debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/send/node_modules/debug/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
 		},
 		"node_modules/send/node_modules/ms": {
 			"version": "2.1.3",
@@ -8727,18 +8697,18 @@
 			}
 		},
 		"node_modules/serve-static": {
-			"version": "2.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.0.0-beta.1.tgz",
-			"integrity": "sha512-DEJ9on/tQeFO2Omj7ovT02lCp1YgP4Kb8W2lv2o/4keTFAbgc8HtH3yPd47++2wv9lvQeqiA7FHFDe5+8c4XpA==",
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
+			"integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
 			"dev": true,
 			"dependencies": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
-				"send": "1.0.0-beta.1"
+				"send": "0.17.2"
 			},
 			"engines": {
-				"node": ">= 0.10"
+				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/setprototypeof": {
@@ -12578,9 +12548,9 @@
 			"dev": true
 		},
 		"array-flatten": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-			"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
 			"dev": true
 		},
 		"array-includes": {
@@ -14559,7 +14529,7 @@
 				"content-type": "~1.0.4",
 				"cookie": "0.4.2",
 				"cookie-signature": "1.0.6",
-				"debug": "3.1.0",
+				"debug": "2.6.9",
 				"depd": "~1.1.2",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
@@ -14568,33 +14538,20 @@
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
 				"methods": "~1.1.2",
-				"mime-types": "~2.1.34",
 				"on-finished": "~2.3.0",
 				"parseurl": "~1.3.3",
-				"path-is-absolute": "1.0.1",
+				"path-to-regexp": "0.1.7",
 				"proxy-addr": "~2.0.7",
 				"qs": "6.9.7",
 				"range-parser": "~1.2.1",
-				"router": "2.0.0-beta.1",
 				"safe-buffer": "5.2.1",
-				"send": "1.0.0-beta.1",
-				"serve-static": "2.0.0-beta.1",
+				"send": "0.17.2",
+				"serve-static": "1.14.2",
 				"setprototypeof": "1.2.0",
 				"statuses": "~1.5.0",
 				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
 			}
 		},
 		"fast-deep-equal": {
@@ -16575,6 +16532,12 @@
 				"picomatch": "^2.2.3"
 			}
 		},
+		"mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true
+		},
 		"mime-db": {
 			"version": "1.51.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -17041,9 +17004,9 @@
 			"dev": true
 		},
 		"path-to-regexp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
-			"integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
 			"dev": true
 		},
 		"path-type": {
@@ -17472,20 +17435,6 @@
 				"glob": "^7.1.3"
 			}
 		},
-		"router": {
-			"version": "2.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/router/-/router-2.0.0-beta.1.tgz",
-			"integrity": "sha512-GLoYgkhAGAiwVda5nt6Qd4+5RAPuQ4WIYLlZ+mxfYICI+22gnIB3eCfmhgV8+uJNPS1/39DOYi/vdrrz0/ouKA==",
-			"dev": true,
-			"requires": {
-				"array-flatten": "3.0.0",
-				"methods": "~1.1.2",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "3.2.0",
-				"setprototypeof": "1.2.0",
-				"utils-merge": "1.0.1"
-			}
-		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -17553,42 +17502,26 @@
 			"dev": true
 		},
 		"send": {
-			"version": "1.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-1.0.0-beta.1.tgz",
-			"integrity": "sha512-OKTRokcl/oo34O8+6aUpj8Jf2Bjw2D0tZzmX0/RvyfVC9ZOZW+HPAWAlhS817IsRaCnzYX1z++h2kHFr2/KNRg==",
+			"version": "0.17.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+			"integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
 			"dev": true,
 			"requires": {
-				"debug": "3.1.0",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
 				"destroy": "~1.0.4",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
 				"http-errors": "1.8.1",
-				"mime-types": "~2.1.34",
+				"mime": "1.6.0",
 				"ms": "2.1.3",
 				"on-finished": "~2.3.0",
 				"range-parser": "~1.2.1",
 				"statuses": "~1.5.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
-					}
-				},
 				"ms": {
 					"version": "2.1.3",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -17608,15 +17541,15 @@
 			}
 		},
 		"serve-static": {
-			"version": "2.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.0.0-beta.1.tgz",
-			"integrity": "sha512-DEJ9on/tQeFO2Omj7ovT02lCp1YgP4Kb8W2lv2o/4keTFAbgc8HtH3yPd47++2wv9lvQeqiA7FHFDe5+8c4XpA==",
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
+			"integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
 			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
-				"send": "1.0.0-beta.1"
+				"send": "0.17.2"
 			}
 		},
 		"setprototypeof": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"prepare": "run-s compile && husky install config/husky"
 	},
 	"peerDependencies": {
-		"express": "^4"
+		"express": "^4 || ^5"
 	},
 	"devDependencies": {
 		"@jest/globals": "27.4.6",

--- a/test/external/run-all-tests
+++ b/test/external/run-all-tests
@@ -5,46 +5,92 @@
 set -e 
 set -o pipefail
 
-# Tests all the variations (JS-TS and CJS-ESM) with the `express-rate-limit` package.
-cd imports/
-for type in "named" "default"; do
-	cd "$type-import"
-	for dir in `ls -d */`; do
-		# cd into the example project
-		cd $dir
-		# Get a fresh install of all node modules
-		rm -rf node_modules
-		npm install
-		# Run the linter and the tests
-		npm run lint
-		npm run test
-		# Go back
-		cd ../
-	done
-	# Go back
-	cd ../
-done
-cd ../
-
-# Tests all external stores with the `express-rate-limit` package.
-# cd into the example project
-cd stores/
-if [[ -z "$CI" ]]; then
-	# If we are not in the CI, start the docker containers needed to run these tests
+# Recreates the docker containers needed for the external store tests. 
+function start_docker {
 	# Stop and delete any existing containers
 	docker stop rate-limit-memcached rate-limit-mongo rate-limit-redis || true
 	docker rm rate-limit-memcached rate-limit-mongo rate-limit-redis || true
-	# Delete any existing files
-	rm -rf /tmp/database || true
+
+	# Database directory for the mongo container
+	data_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'rate-limit-mongo-database')
+
 	# Start all the containers
 	docker run --name rate-limit-memcached -p 11211:11211 -d memcached
-	docker run --name rate-limit-mongo -p 27017:27017 -v /tmp/database:/data/db -d mongo
+	docker run --name rate-limit-mongo -p 27017:27017 -v $data_dir:/data/db -d mongo
 	docker run --name rate-limit-redis -p 6379:6379 -d redis
-fi
-# Get a fresh install of all the node modules
-rm -rf node_modules
-npm install
-# Run the tests
-npm run test
-# Go back
-cd ../
+
+	# Wait for a few seconds
+	sleep 10
+}
+
+# Tests all the variations (JS/TS and CJS/ESM) with the package.
+function run_import_tests {
+	# cd into the imports folder
+	cd imports/
+	# For each type of import (named and default), run the tests
+	for type in "named" "default"; do
+		cd "$type-import"
+		
+		for dir in `ls -d */`; do
+			# cd into the example project
+			cd $dir
+
+			# Get a fresh install of all node modules
+			rm -rf node_modules
+			npm install
+			# Run the linter and the tests
+			npm run lint
+			npm test
+
+			# Install Express v5
+			npm install express@5.0.0-beta.1
+			# Run the tests with this version
+			npm run lint
+			npm test
+			# Restore the version
+			git restore package.json
+
+			# Go back into the next variation
+			cd ../
+		done
+		
+		# Go back
+		cd ../
+	done
+
+	# Go back
+	cd ../
+}
+
+# Tests all external stores with the package.
+function run_store_tests {
+	# cd into the example project
+	cd stores/
+
+	# Start the containers
+	start_docker
+
+	# Get a fresh install of all the node modules
+	rm -rf node_modules
+	npm install
+	
+	# Run the tests with Express v4
+	npm run test
+
+	# Restart the containers
+	start_docker
+
+	# Install Express v5
+	npm install express@5.0.0-beta.1
+	# Run the tests with this version
+	npm test
+	# Restore the version
+	git restore package.json
+
+	# Go back
+	cd ../
+}
+
+# Run the tests!
+run_import_tests
+run_store_tests

--- a/test/external/run-all-tests
+++ b/test/external/run-all-tests
@@ -1,12 +1,41 @@
 #!/bin/bash
 # Run all the external tests
 
+# -- Setup --
+
 # Fail if any command fails
-set -e 
-set -o pipefail
+set -euo pipefail
+
+# -- Console Output --
+
+# Define colors so we can print colorful text
+color_red="\033[0;31m"
+color_green="\033[0;32m"
+color_yellow="\033[0;33m"
+color_cyan="\033[0;36m"
+color_dimmed="\033[1;30m"
+color_normal="\033[0m"
+
+# Define output helper functions
+# Print functions with different colors
+function print_success {
+	echo -e "${color_green}=> $1${color_normal}\n"
+}
+function print_warning {
+	echo -e "${color_yellow}=> $1${color_normal}\n"
+}
+function print_error {
+	echo -e "${color_red}=> $1${color_normal}\n"
+}
+function print_info {
+	echo -e "${color_cyan}=> $1${color_normal}\n"
+}
+
+# -- Utility Functions --
 
 # Recreates the docker containers needed for the external store tests. 
 function start_docker {
+	print_info "stopping docker containers"
 	# Stop and delete any existing containers
 	docker stop rate-limit-memcached rate-limit-mongo rate-limit-redis || true
 	docker rm rate-limit-memcached rate-limit-mongo rate-limit-redis || true
@@ -14,6 +43,7 @@ function start_docker {
 	# Database directory for the mongo container
 	data_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'rate-limit-mongo-database')
 
+	print_info "restarting docker containers"
 	# Start all the containers
 	docker run --name rate-limit-memcached -p 11211:11211 -d memcached
 	docker run --name rate-limit-mongo -p 27017:27017 -v $data_dir:/data/db -d mongo
@@ -21,10 +51,16 @@ function start_docker {
 
 	# Wait for a few seconds
 	sleep 10
+
+	print_success "successfully started docker containers"
 }
+
+# -- Main --
 
 # Tests all the variations (JS/TS and CJS/ESM) with the package.
 function run_import_tests {
+	print_info "running import tests"
+
 	# cd into the imports folder
 	cd imports/
 	# For each type of import (named and default), run the tests
@@ -32,6 +68,7 @@ function run_import_tests {
 		cd "$type-import"
 		
 		for dir in `ls -d */`; do
+			print_info "running $dir variation for $type imports (express 4)"
 			# cd into the example project
 			cd $dir
 
@@ -41,7 +78,10 @@ function run_import_tests {
 			# Run the linter and the tests
 			npm run lint
 			npm test
+			echo
+			print_success "sucessfully ran $dir variation for $type imports (express 4)"
 
+			print_info "running $dir variation for $type imports (express 5)"
 			# Install Express v5
 			npm install express@5.0.0-beta.1
 			# Run the tests with this version
@@ -49,6 +89,8 @@ function run_import_tests {
 			npm test
 			# Restore the version
 			git restore package.json
+			echo
+			print_success "sucessfully ran $dir variation for $type imports (express 5)"
 
 			# Go back into the next variation
 			cd ../
@@ -60,10 +102,14 @@ function run_import_tests {
 
 	# Go back
 	cd ../
+
+	print_success "successfully ran all import tests"
 }
 
 # Tests all external stores with the package.
 function run_store_tests {
+	print_info "running store tests"
+
 	# cd into the example project
 	cd stores/
 
@@ -73,13 +119,15 @@ function run_store_tests {
 	# Get a fresh install of all the node modules
 	rm -rf node_modules
 	npm install
-	
+
+	print_info "running store tests (express 4)"
 	# Run the tests with Express v4
 	npm run test
 
 	# Restart the containers
 	start_docker
 
+	print_info "running store tests (express 5)"
 	# Install Express v5
 	npm install express@5.0.0-beta.1
 	# Run the tests with this version
@@ -89,6 +137,8 @@ function run_store_tests {
 
 	# Go back
 	cd ../
+
+	print_success "successfully ran all store tests"
 }
 
 # Run the tests!


### PR DESCRIPTION
<!--
	Hi there! Thanks for contributing! Please fill in this template to help us
	review and merge the PR as quickly and easily as possible!
-->

## Related Issues

<!--
	If this is a bug fix, or adds a feature mentioned in another issue, mention
	it as follows:

	- Closes #10
	- Fixes #15
-->

## What Does This PR Do?
This PR will resolve the peer dependency error fix for express v5

<!--
	Explain what has been added/changed/removed, in
	[keepachangelog.com](https://keepachangelog.com) style.
-->

### Added

<!--
	- Added a new method on the limiter object to reset the count for a certain IP [#10]
-->

### Changed

<!--
	- Deprecated `global` option
	- Fixed test for deprecated options [#15]
-->

### Removed

<!--
	- Removed deprecated `headers` option
-->

## Caveats/Problems/Issues

<!--
	Any weird code/problems you faced while making this PR. Feel free to ask for
	help with anything, especially if it's your first time contributing!
-->

## Checklist

- [ ] The issues that this PR fixes/closes have been mentioned above.
- [ ] What this PR adds/changes/removes has been explained.
- [ ] All tests (`npm test`) pass.
- [ ] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [ ] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
