### PR TITLE
fix types missing in ESM monorepos

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs"
 		}


### PR DESCRIPTION
## Related Issues

- Fixes #319 

## What Does This PR Do?

Fixes types missing in ESM monorepos

### Added

Add ``types`` to module exports: https://nodejs.org/api/packages.html#community-conditions-definitions

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All tests (`npm test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
