### PR TITLE
Added MemoryStore shutdown method

### DIFF
--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -42,6 +42,11 @@ export default class MemoryStore implements Store {
 	resetTime!: Date
 
 	/**
+	 * Reference to the active timer.
+	 */
+	interval?: NodeJS.Timer
+
+	/**
 	 * Method that initializes the store.
 	 *
 	 * @param options {Options} - The options used to setup the middleware.
@@ -57,11 +62,11 @@ export default class MemoryStore implements Store {
 
 		// Reset hit counts for ALL clients every `windowMs` - this will also
 		// re-calculate the `resetTime`
-		const interval = setInterval(async () => {
+		this.interval = setInterval(async () => {
 			await this.resetAll()
 		}, this.windowMs)
-		if (interval.unref) {
-			interval.unref()
+		if (this.interval.unref) {
+			this.interval.unref()
 		}
 	}
 
@@ -117,5 +122,17 @@ export default class MemoryStore implements Store {
 	async resetAll(): Promise<void> {
 		this.hits = {}
 		this.resetTime = calculateNextResetTime(this.windowMs)
+	}
+
+	/**
+	 * Method to stop the timer.
+	 *
+	 * @public
+	 */
+	shutdown(): void {
+		if (this.interval !== undefined) {
+			clearInterval(this.interval)
+			this.interval = undefined
+		}
 	}
 }

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -129,9 +129,6 @@ export default class MemoryStore implements Store {
 	 * @public
 	 */
 	shutdown(): void {
-		if (this.interval !== undefined) {
-			clearInterval(this.interval)
-			this.interval = undefined
-		}
+		clearInterval(this.interval)
 	}
 }

--- a/source/memory-store.ts
+++ b/source/memory-store.ts
@@ -52,12 +52,12 @@ export default class MemoryStore implements Store {
 	 * @param options {Options} - The options used to setup the middleware.
 	 */
 	init(options: Options): void {
-		// Get the duration of a window from the options
+		// Get the duration of a window from the options.
 		this.windowMs = options.windowMs
-		// Then calculate the reset time using that
+		// Then calculate the reset time using that.
 		this.resetTime = calculateNextResetTime(this.windowMs)
 
-		// Initialise the hit counter map
+		// Initialise the hit counter map.
 		this.hits = {}
 
 		// Reset hit counts for ALL clients every `windowMs` - this will also
@@ -65,9 +65,8 @@ export default class MemoryStore implements Store {
 		this.interval = setInterval(async () => {
 			await this.resetAll()
 		}, this.windowMs)
-		if (this.interval.unref) {
-			this.interval.unref()
-		}
+		// Cleaning up the interval will be taken care of by the `shutdown` method.
+		if (this.interval.unref) this.interval.unref()
 	}
 
 	/**
@@ -98,9 +97,8 @@ export default class MemoryStore implements Store {
 	 */
 	async decrement(key: string): Promise<void> {
 		const current = this.hits[key]
-		if (current) {
-			this.hits[key] = current - 1
-		}
+
+		if (current) this.hits[key] = current - 1
 	}
 
 	/**
@@ -125,7 +123,8 @@ export default class MemoryStore implements Store {
 	}
 
 	/**
-	 * Method to stop the timer.
+	 * Method to stop the timer (if currently running) and prevent any memory
+	 * leaks.
 	 *
 	 * @public
 	 */

--- a/source/types.ts
+++ b/source/types.ts
@@ -157,6 +157,11 @@ export interface Store {
 	 * Method to reset everyone's hit counter.
 	 */
 	resetAll?: () => Promise<void> | void
+
+	/**
+	 * Method to shutdown the store, stop timers, and release all resources.
+	 */
+	shutdown?: () => Promise<void> | void
 }
 
 /**

--- a/test/external/imports/default-import/ts-cjs/source/app.ts
+++ b/test/external/imports/default-import/ts-cjs/source/app.ts
@@ -8,7 +8,7 @@ import rateLimit, {
 	IncrementResponse,
 } from 'express-rate-limit'
 
-class TestStore implements Store {
+export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
 	async increment(key: string): Promise<IncrementResponse> {
@@ -28,19 +28,25 @@ class TestStore implements Store {
 	async resetKey(key: string): Promise<void> {
 		delete this.hits[key]
 	}
+
+	async shutdown(): Promise<void> {
+		console.log('Shutdown successful')
+	}
 }
 
-const app = createServer()
+export const app = createServer()
+
+export const store = Math.floor(Math.random() * 2)
+	? new TestStore()
+	: new MemoryStore()
 
 app.use(
 	rateLimit({
 		max: 2,
 		legacyHeaders: false,
 		standardHeaders: true,
-		store: Math.floor(Math.random() * 2) ? new TestStore() : new MemoryStore(),
+		store,
 	}),
 )
 
 app.get('/', (request, response) => response.send('Hello!'))
-
-export default app

--- a/test/external/imports/default-import/ts-cjs/source/index.ts
+++ b/test/external/imports/default-import/ts-cjs/source/index.ts
@@ -1,7 +1,7 @@
 // /source/index.ts
 // Run the server
 
-import app from './app'
+import { app } from './app'
 
 app.listen(8080, () =>
 	console.log('Make a GET request to http://localhost:8080!'),

--- a/test/external/imports/default-import/ts-cjs/test/server-test.ts
+++ b/test/external/imports/default-import/ts-cjs/test/server-test.ts
@@ -8,11 +8,12 @@ import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
 	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
+
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(429)
+
 	await store.shutdown()
-	if (store instanceof TestStore) {
+	if (store instanceof TestStore)
 		expect(console.log).toHaveBeenCalledWith('Shutdown successful')
-	}
 })

--- a/test/external/imports/default-import/ts-cjs/test/server-test.ts
+++ b/test/external/imports/default-import/ts-cjs/test/server-test.ts
@@ -1,12 +1,18 @@
 // /test/server-test.ts
 // Tests the server's rate limiting middleware
 
+import { jest } from '@jest/globals'
 import { agent as request } from 'supertest'
 
-import app from '../source/app.js'
+import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
+	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(429)
+	await store.shutdown()
+	if (store instanceof TestStore) {
+		expect(console.log).toHaveBeenCalledWith('Shutdown successful')
+	}
 })

--- a/test/external/imports/default-import/ts-cjs/test/server-test.ts
+++ b/test/external/imports/default-import/ts-cjs/test/server-test.ts
@@ -7,7 +7,7 @@ import { agent as request } from 'supertest'
 import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
-	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
+	jest.spyOn(global.console, 'log').mockImplementation(() => {})
 
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)

--- a/test/external/imports/default-import/ts-esm/source/app.ts
+++ b/test/external/imports/default-import/ts-esm/source/app.ts
@@ -8,7 +8,7 @@ import rateLimit, {
 	IncrementResponse,
 } from 'express-rate-limit'
 
-class TestStore implements Store {
+export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
 	async increment(key: string): Promise<IncrementResponse> {
@@ -28,19 +28,25 @@ class TestStore implements Store {
 	async resetKey(key: string): Promise<void> {
 		delete this.hits[key]
 	}
+
+	async shutdown(): Promise<void> {
+		console.log('Shutdown successful')
+	}
 }
 
-const app = createServer()
+export const app = createServer()
+
+export const store = Math.floor(Math.random() * 2)
+	? new TestStore()
+	: new MemoryStore()
 
 app.use(
 	rateLimit({
 		max: 2,
 		legacyHeaders: false,
 		standardHeaders: true,
-		store: Math.floor(Math.random() * 2) ? new TestStore() : new MemoryStore(),
+		store,
 	}),
 )
 
 app.get('/', (request, response) => response.send('Hello!'))
-
-export default app

--- a/test/external/imports/default-import/ts-esm/source/index.ts
+++ b/test/external/imports/default-import/ts-esm/source/index.ts
@@ -1,7 +1,7 @@
 // /source/index.ts
 // Run the server
 
-import app from './app.js'
+import { app } from './app.js'
 
 app.listen(8080, () =>
 	console.log('Make a GET request to http://localhost:8080!'),

--- a/test/external/imports/default-import/ts-esm/test/server-test.ts
+++ b/test/external/imports/default-import/ts-esm/test/server-test.ts
@@ -8,11 +8,12 @@ import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
 	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
+
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(429)
+
 	await store.shutdown()
-	if (store instanceof TestStore) {
+	if (store instanceof TestStore)
 		expect(console.log).toHaveBeenCalledWith('Shutdown successful')
-	}
 })

--- a/test/external/imports/default-import/ts-esm/test/server-test.ts
+++ b/test/external/imports/default-import/ts-esm/test/server-test.ts
@@ -1,12 +1,18 @@
 // /test/server-test.ts
 // Tests the server's rate limiting middleware
 
+import { jest } from '@jest/globals'
 import { agent as request } from 'supertest'
 
-import app from '../source/app.js'
+import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
+	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(429)
+	await store.shutdown()
+	if (store instanceof TestStore) {
+		expect(console.log).toHaveBeenCalledWith('Shutdown successful')
+	}
 })

--- a/test/external/imports/default-import/ts-esm/test/server-test.ts
+++ b/test/external/imports/default-import/ts-esm/test/server-test.ts
@@ -7,7 +7,7 @@ import { agent as request } from 'supertest'
 import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
-	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
+	jest.spyOn(global.console, 'log').mockImplementation(() => {})
 
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)

--- a/test/external/imports/named-import/ts-cjs/source/app.ts
+++ b/test/external/imports/named-import/ts-cjs/source/app.ts
@@ -9,7 +9,7 @@ import {
 	IncrementResponse,
 } from 'express-rate-limit'
 
-class TestStore implements Store {
+export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
 	async increment(key: string): Promise<IncrementResponse> {
@@ -29,19 +29,25 @@ class TestStore implements Store {
 	async resetKey(key: string): Promise<void> {
 		delete this.hits[key]
 	}
+
+	async shutdown(): Promise<void> {
+		console.log('Shutdown successful')
+	}
 }
 
-const app = createServer()
+export const app = createServer()
+
+export const store = Math.floor(Math.random() * 2)
+	? new TestStore()
+	: new MemoryStore()
 
 app.use(
 	rateLimit({
 		max: 2,
 		legacyHeaders: false,
 		standardHeaders: true,
-		store: Math.floor(Math.random() * 2) ? new TestStore() : new MemoryStore(),
+		store,
 	}),
 )
 
 app.get('/', (request, response) => response.send('Hello!'))
-
-export default app

--- a/test/external/imports/named-import/ts-cjs/test/server-test.ts
+++ b/test/external/imports/named-import/ts-cjs/test/server-test.ts
@@ -8,11 +8,12 @@ import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
 	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
+
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(429)
+
 	await store.shutdown()
-	if (store instanceof TestStore) {
+	if (store instanceof TestStore)
 		expect(console.log).toHaveBeenCalledWith('Shutdown successful')
-	}
 })

--- a/test/external/imports/named-import/ts-cjs/test/server-test.ts
+++ b/test/external/imports/named-import/ts-cjs/test/server-test.ts
@@ -1,12 +1,18 @@
 // /test/server-test.ts
 // Tests the server's rate limiting middleware
 
+import { jest } from '@jest/globals'
 import { agent as request } from 'supertest'
 
-import app from '../source/app.js'
+import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
+	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(429)
+	await store.shutdown()
+	if (store instanceof TestStore) {
+		expect(console.log).toHaveBeenCalledWith('Shutdown successful')
+	}
 })

--- a/test/external/imports/named-import/ts-cjs/test/server-test.ts
+++ b/test/external/imports/named-import/ts-cjs/test/server-test.ts
@@ -7,7 +7,7 @@ import { agent as request } from 'supertest'
 import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
-	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
+	jest.spyOn(global.console, 'log').mockImplementation(() => {})
 
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)

--- a/test/external/imports/named-import/ts-esm/source/app.ts
+++ b/test/external/imports/named-import/ts-esm/source/app.ts
@@ -9,7 +9,7 @@ import {
 	IncrementResponse,
 } from 'express-rate-limit'
 
-class TestStore implements Store {
+export class TestStore implements Store {
 	hits: Record<string, number> = {}
 
 	async increment(key: string): Promise<IncrementResponse> {
@@ -29,19 +29,25 @@ class TestStore implements Store {
 	async resetKey(key: string): Promise<void> {
 		delete this.hits[key]
 	}
+
+	async shutdown(): Promise<void> {
+		console.log('Shutdown successful')
+	}
 }
 
-const app = createServer()
+export const app = createServer()
+
+export const store = Math.floor(Math.random() * 2)
+	? new TestStore()
+	: new MemoryStore()
 
 app.use(
 	rateLimit({
 		max: 2,
 		legacyHeaders: false,
 		standardHeaders: true,
-		store: Math.floor(Math.random() * 2) ? new TestStore() : new MemoryStore(),
+		store,
 	}),
 )
 
 app.get('/', (request, response) => response.send('Hello!'))
-
-export default app

--- a/test/external/imports/named-import/ts-esm/test/server-test.ts
+++ b/test/external/imports/named-import/ts-esm/test/server-test.ts
@@ -8,11 +8,12 @@ import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
 	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
+
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(429)
+
 	await store.shutdown()
-	if (store instanceof TestStore) {
+	if (store instanceof TestStore)
 		expect(console.log).toHaveBeenCalledWith('Shutdown successful')
-	}
 })

--- a/test/external/imports/named-import/ts-esm/test/server-test.ts
+++ b/test/external/imports/named-import/ts-esm/test/server-test.ts
@@ -1,12 +1,18 @@
 // /test/server-test.ts
 // Tests the server's rate limiting middleware
 
+import { jest } from '@jest/globals'
 import { agent as request } from 'supertest'
 
-import app from '../source/app.js'
+import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
+	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(429)
+	await store.shutdown()
+	if (store instanceof TestStore) {
+		expect(console.log).toHaveBeenCalledWith('Shutdown successful')
+	}
 })

--- a/test/external/imports/named-import/ts-esm/test/server-test.ts
+++ b/test/external/imports/named-import/ts-esm/test/server-test.ts
@@ -7,7 +7,7 @@ import { agent as request } from 'supertest'
 import { app, store, TestStore } from '../source/app.js'
 
 test('rate limiting middleware', async () => {
-	jest.spyOn(global.console, 'log').mockImplementation(() => undefined)
+	jest.spyOn(global.console, 'log').mockImplementation(() => {})
 
 	await request(app).get('/').expect(200)
 	await request(app).get('/').expect(200)

--- a/test/library/memory-store-test.ts
+++ b/test/library/memory-store-test.ts
@@ -76,6 +76,14 @@ describe('memory store test', () => {
 		expect(totalHitsTwo).toEqual(1)
 	})
 
+	it('clears the timer when `shutdown` is called', async () => {
+		const store = new MemoryStore()
+		store.init({ windowMs: -1 } as Options)
+		expect(store.interval).toBeDefined()
+		store.shutdown()
+		expect(store.interval).toBeUndefined()
+	})
+
 	describe('reset time', () => {
 		beforeEach(() => {
 			jest.useFakeTimers()

--- a/test/library/memory-store-test.ts
+++ b/test/library/memory-store-test.ts
@@ -9,6 +9,7 @@ import MemoryStore from '../../source/memory-store.js'
 describe('memory store test', () => {
 	beforeEach(() => {
 		jest.useFakeTimers()
+		jest.spyOn(global, 'clearInterval')
 	})
 	afterEach(() => {
 		jest.useRealTimers()
@@ -81,7 +82,7 @@ describe('memory store test', () => {
 		store.init({ windowMs: -1 } as Options)
 		expect(store.interval).toBeDefined()
 		store.shutdown()
-		expect(store.interval).toBeUndefined()
+		expect(clearInterval).toHaveBeenCalledWith(store.interval)
 	})
 
 	describe('reset time', () => {


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/nfriedly/express-rate-limit/issues/320

## What Does This PR Do?

### Added

Added `MemoryStore.shutdown` which clears the timer and allows applications to completely stop a running instance of MemoryStore.

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All tests (`npm test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
