### PR TITLE
validations: add `max: 0` change warning

### DIFF
--- a/source/lib.ts
+++ b/source/lib.ts
@@ -304,9 +304,8 @@ const rateLimit = (
 
 			// Get a unique key for the client
 			const key = await config.keyGenerator(request, response)
-			// Increment the client's hit counter by one
+			// Increment the client's hit counter by one, and make sure it's only by one
 			const { totalHits, resetTime } = await config.store.increment(key)
-
 			config.validations.singleCount(request, config.store, key)
 
 			// Get the quota (max number of hits) for each client
@@ -314,8 +313,9 @@ const rateLimit = (
 				typeof config.max === 'function'
 					? config.max(request, response)
 					: config.max
-
 			const maxHits = await retrieveQuota
+			config.validations.max(maxHits)
+
 			// Set the rate limit information on the augmented request object
 			augmentedRequest[config.requestPropertyName] = {
 				limit: maxHits,
@@ -394,7 +394,7 @@ const rateLimit = (
 
 			// Call the `onLimitReached` callback on the first request where client
 			// exceeds their rate limit
-			// NOTE: `onLimitReached` is deprecated, this should be removed in v7.x
+			// TODO: `onLimitReached` is deprecated, this should be removed in v7.x
 			if (maxHits && totalHits === maxHits + 1) {
 				config.onLimitReached(request, response, options)
 			}

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -202,7 +202,6 @@ export class Validations {
 	 *
 	 * @returns {void}
 	 */
-	// TODO: Remove in v7.0.0
 	max(max: number) {
 		this.wrap(() => {
 			if (max === 0) {

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -35,23 +35,7 @@ class ValidationError extends Error {
  * A warning logged when the configuration used will/has been changed by a
  * newly released version of the library.
  */
-class ChangeWarning extends ValidationError {
-	name: string
-
-	/**
-	 * The code must be a string, in snake case and all capital, that starts with
-	 * the substring `WRN_ERL_`.
-	 *
-	 * The message must be a string, starting with an uppercase character,
-	 * describing the issue in detail.
-	 */
-	constructor(code: string, message: string) {
-		super(code, message)
-
-		// `this.constructor.name` is the class name
-		this.name = this.constructor.name
-	}
-}
+class ChangeWarning extends ValidationError {}
 
 /**
  * The validations that can be run, as well as the methods to run them.

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -22,7 +22,7 @@ class ValidationError extends Error {
 	 */
 	constructor(code: string, message: string) {
 		const url = `https://express-rate-limit.github.io/${code}/`
-		super(`${message} See ${url} for more information on this error.`)
+		super(`${message} See ${url} for more information.`)
 
 		// `this.constructor.name` is the class name
 		this.name = this.constructor.name

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -172,6 +172,25 @@ export class Validations {
 		})
 	}
 
+	/**
+	 * Warns the user that the behaviour for `max: 0` is changing in the next
+	 * major release.
+	 *
+	 * @param max {number} - The maximum number of hits per client.
+	 *
+	 * @returns {void}
+	 */
+	// TODO: Remove in v7.0.0
+	max(max: number) {
+		this.wrap(() => {
+			if (max === 0) {
+				console.warn(
+					`The behaviour shown when 'max' is set to zero will change in v7.0.0. Please see https://express-rate-limit.github.io/max_warning for more information on this change.`,
+				)
+			}
+		})
+	}
+
 	private wrap(validation: () => void) {
 		if (!this.enabled) {
 			return

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -185,7 +185,7 @@ export class Validations {
 		this.wrap(() => {
 			if (max === 0) {
 				console.warn(
-					`The behaviour shown when 'max' is set to zero will change in v7.0.0. Please see https://express-rate-limit.github.io/WRN_MAX for more information on this change.`,
+					`The behaviour shown when 'max' is set to zero will change in v7.0.0. Please see https://express-rate-limit.github.io/WRN_MAX/ for more information on this change.`,
 				)
 			}
 		})

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -185,7 +185,7 @@ export class Validations {
 		this.wrap(() => {
 			if (max === 0) {
 				console.warn(
-					`The behaviour shown when 'max' is set to zero will change in v7.0.0. Please see https://express-rate-limit.github.io/max_warning for more information on this change.`,
+					`The behaviour shown when 'max' is set to zero will change in v7.0.0. Please see https://express-rate-limit.github.io/WRN_MAX for more information on this change.`,
 				)
 			}
 		})

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -155,7 +155,6 @@ describe('validations tests', () => {
 		})
 	})
 
-	// TODO: Remove before releasing v7.0.0.
 	describe('max', () => {
 		it('should log a warning if max is set to 0', () => {
 			validations.max(0)

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -17,6 +17,7 @@ describe('validations tests', () => {
 
 	beforeEach(() => {
 		jest.spyOn(console, 'error').mockImplementation(() => {})
+		jest.spyOn(console, 'warn').mockImplementation(() => {})
 	})
 	afterEach(() => {
 		jest.restoreAllMocks()
@@ -151,6 +152,19 @@ describe('validations tests', () => {
 			expect(console.error).not.toBeCalled()
 			validations.singleCount(request2 as any, store as Store, key)
 			expect(console.error).not.toBeCalled()
+		})
+	})
+
+	// TODO: Remove before releasing v7.0.0.
+	describe('max', () => {
+		it('should log a warning if max is set to 0', () => {
+			validations.max(0)
+			expect(console.warn).toBeCalled()
+		})
+
+		it('should not log a warning if max is set to a non zero number', () => {
+			validations.max(3)
+			expect(console.warn).not.toBeCalled()
 		})
 	})
 


### PR DESCRIPTION
## Related Issues

- Implements #369

## What Does This PR Do?

### Added

- A validation check that warns users that set `max: 0` that the behaviour will change in the not-so-distant future. 

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All library tests (`npm run test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
