### PR TITLE
validations: add onLimitReached deprecation warning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -430,8 +430,8 @@ const limiter = rateLimit({
 > `function`
 
 A (sync/async) function that accepts the Express `request` and `response`
-objects that is called when a client has reached their rate limit, and will be
-rate limited on their next request.
+objects that is called the on the request where a client has just exceeded their
+rate limit.
 
 This method was
 [deprecated in v6](https://github.com/express-rate-limit/express-rate-limit/releases/v6.0.0) -

--- a/source/lib.ts
+++ b/source/lib.ts
@@ -171,6 +171,8 @@ const parseOptions = (passedOptions: Partial<Options>): Configuration => {
 	// Create the validator before even parsing the rest of the options
 	const validations = new Validations(notUndefinedOptions?.validate ?? true)
 
+	validations.onLimitReached(notUndefinedOptions.onLimitReached)
+
 	// See ./types.ts#Options for a detailed description of the options and their
 	// defaults.
 	const config: Configuration = {

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -3,7 +3,7 @@
 
 import { isIP } from 'node:net'
 import type { Request } from 'express'
-import type { Store } from './types'
+import type { RateLimitReachedEventHandler, Store } from './types'
 
 /**
  * An error thrown/returned when a validation error occurs.
@@ -192,6 +192,25 @@ export class Validations {
 				throw new ChangeWarning(
 					'WRN_ERL_MAX_ZERO',
 					`Setting max to 0 disables rate limiting in express-rate-limit v6 and older, but will cause all requests to be blocked in v7`,
+				)
+			}
+		})
+	}
+
+	/**
+	 * Warns the user that the `onLimitReached` option is deprecated and will be removed in the next
+	 * major release.
+	 *
+	 * @param onLimitReached {function|undefined} - The maximum number of hits per client.
+	 *
+	 * @returns {void}
+	 */
+	onLimitReached(onLimitReached?: RateLimitReachedEventHandler) {
+		this.wrap(() => {
+			if (onLimitReached) {
+				throw new ChangeWarning(
+					'WRN_ERL_DEPRECATED_ON_LIMIT_REACHED',
+					`The onLimitReached configuration option is deprecated and will be removed in express-rate-limit v7.`,
 				)
 			}
 		})

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -169,10 +169,14 @@ describe('validations tests', () => {
 
 	describe('onLimitReached', () => {
 		it('should log a warning if onLimitReached is set', () => {
-			validations.onLimitReached(undefined)
-			expect(console.warn).not.toBeCalled()
 			validations.onLimitReached(() => {})
 			expect(console.warn).toBeCalled()
+			expect(console.error).not.toBeCalled()
+		})
+
+		it('should not  log a warning if onLimitReached is unset', () => {
+			validations.onLimitReached(undefined)
+			expect(console.warn).not.toBeCalled()
 			expect(console.error).not.toBeCalled()
 		})
 	})

--- a/test/library/validation-test.ts
+++ b/test/library/validation-test.ts
@@ -167,6 +167,16 @@ describe('validations tests', () => {
 		})
 	})
 
+	describe('onLimitReached', () => {
+		it('should log a warning if onLimitReached is set', () => {
+			validations.onLimitReached(undefined)
+			expect(console.warn).not.toBeCalled()
+			validations.onLimitReached(() => {})
+			expect(console.warn).toBeCalled()
+			expect(console.error).not.toBeCalled()
+		})
+	})
+
 	describe('disable', () => {
 		it('should initialize disabled when passed false', () => {
 			const disabledValidator = new Validations(false)


### PR DESCRIPTION
<!--
	Hi there! Thanks for contributing! Please fill in this template to help us
	review and merge the PR as quickly and easily as possible!
-->

## Related Issues

Relates to https://github.com/express-rate-limit/express-rate-limit/discussions/372

## What Does This PR Do?

Adds a deprecation warning for use of the `onLimitReached` config option.

### Added

- `onLimitReached` deprecation warning


## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All library tests (`npm run test`) pass.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
- [x] Add new warning to error codes page in wiki
- [x] Add redirect for new warning
