### PR TITLE
Fix: don't warn for extra config from express-slow-down

### DIFF
--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.2.1](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v8.2.1)
+
+### Fixed
+
+- Don't log ERR_ERL_UNKNOWN_OPTION when used with express-rate-limit
+
 ## [8.2.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v8.2.0)
 
 ### Added

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -342,6 +342,10 @@ const validations = {
 		}
 		const validOptions = Object.keys(optionsMap).concat(
 			'draft_polli_ratelimit_headers', // not a valid option anymore, but we have a more specific check for this one, so don't warn for it here
+			// from express-slow-down - https://github.com/express-rate-limit/express-slow-down/blob/main/source/types.ts#L65
+			'delayAfter',
+			'delayMs',
+			'maxDelayMs',
 		)
 		for (const key of Object.keys(passedOptions)) {
 			if (!validOptions.includes(key)) {


### PR DESCRIPTION
These are known options, even if they aren't used by ERL directly.

Fixes https://github.com/express-rate-limit/express-slow-down/issues/66 (fix 1 of 2, see also https://github.com/express-rate-limit/express-slow-down/pull/67)