### PR TITLE
test: bump timeout in flakey skipFailedRequests test

### DIFF
--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.4.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v8.4.0)
+
+### Added
+
+- Custom logger support: new logger option, interface, and default
+  implementation that maintains the previous console.warn/console.error
+  behavior.
+
 ## [8.3.2](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v8.3.2)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "express-rate-limit",
-	"version": "8.3.2",
+	"version": "8.4.0",
 	"description": "Basic IP rate-limiting middleware for Express. Use to limit repeated requests to public APIs and/or endpoints such as password reset.",
 	"author": {
 		"name": "Nathan Friedly",

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ default values.
 | [`skipFailedRequests`]     | `boolean`                                 | Uncount 4xx/5xx responses.                                                                      |
 | [`requestWasSuccessful`]   | `function`                                | Used by `skipSuccessfulRequests` and `skipFailedRequests`.                                      |
 | [`validate`]               | `boolean` \| `object`                     | Enable or disable built-in validation checks.                                                   |
+| [`logger`]                 | `Logger`                                  | Custom logger                                                                                   |
 
 ## Thank You
 
@@ -134,3 +135,5 @@ MIT © [Nathan Friedly](http://nfriedly.com/),
 	https://express-rate-limit.mintlify.app/reference/configuration#requestwassuccessful
 [`validate`]:
 	https://express-rate-limit.mintlify.app/reference/configuration#validate
+[`logger`]:
+	https://express-rate-limit.mintlify.app/reference/configuration#logger

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -4,7 +4,7 @@
 import { EventEmitter } from 'node:events'
 import { platform } from 'node:process'
 
-import { describe, expect, it, jest } from '@jest/globals'
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import type { NextFunction, Request, Response } from 'express'
 import { agent as request } from 'supertest'
 import rateLimit, {
@@ -620,45 +620,40 @@ describe('middleware test', () => {
 		expect(store.decrementWasCalled).toEqual(true)
 	})
 
-	describe('server-based tests', () => {
-		beforeEach(() => {
-			jest.setTimeout(60_000)
-		})
+	;(platform === 'darwin' ? it.skip : it).each([
+		['modern', new MockStore()],
+		['legacy', new MockLegacyStore()],
+		['compat', new MockBackwardCompatibleStore()],
+	])(
+		'should decrement hits when response closes and `skipFailedRequests` is set to true (%s store) (server)',
+		async (name, store) => {
+			jest.useRealTimers()
 
-		;(platform === 'darwin' ? it.skip : it).each([
-			['modern', new MockStore()],
-			['legacy', new MockLegacyStore()],
-			['compat', new MockBackwardCompatibleStore()],
-		])(
-			'should decrement hits when response closes and `skipFailedRequests` is set to true (%s store) (server)',
-			async (name, store) => {
-				jest.useRealTimers()
+			const app = createServer(
+				rateLimit({
+					skipFailedRequests: true,
+					store,
+				}),
+			)
 
-				const app = createServer(
-					rateLimit({
-						skipFailedRequests: true,
-						store,
-					}),
-				)
+			let _resolve: () => void
+			const connectionClosed = new Promise<void>((resolve) => {
+				_resolve = resolve
+			})
 
-				let _resolve: () => void
-				const connectionClosed = new Promise<void>((resolve) => {
-					_resolve = resolve
-				})
+			app.get('/hang-server', (_request, response) => {
+				response.on('close', _resolve)
+			})
 
-				app.get('/hang-server', (_request, response) => {
-					response.on('close', _resolve)
-				})
+			// note: if the timeout is too short (e.g. 10ms), the test will sometimes fail on widows, presumably because it's timing out too quickly
+			const hangRequest = request(app).get('/hang-server').timeout(50)
 
-				const hangRequest = request(app).get('/hang-server').timeout(10)
+			await expect(hangRequest).rejects.toThrow()
+			await connectionClosed
 
-				await expect(hangRequest).rejects.toThrow()
-				await connectionClosed
-
-				expect(store.decrementWasCalled).toEqual(true)
-			},
-		)
-	})
+			expect(store.decrementWasCalled).toEqual(true)
+		},
+	)
 
 	it.each([
 		['modern', new MockStore()],


### PR DESCRIPTION
Working on the theory that the short 10ms *request* timeout can sometimes trigger before processing of the request even starts, this bumps that timeout from 10ms to 50ms. 

It also removes the code bumping the timeout for the overall test, partially because it doesn't seem to work, and partially because the test should be finished in well under the default 30s timeout anyways.

Followup to #617 & #611

I want to re-run the windows CI tests a few times and see if it passes all of them before merging.

Tip for reviewing: hide the whitespace changes - https://github.com/express-rate-limit/express-rate-limit/pull/618/changes?w=1

CC @AzmeerX