### PR TITLE
feat: async store init

### DIFF
--- a/docs/guides/creating-a-store.mdx
+++ b/docs/guides/creating-a-store.mdx
@@ -28,6 +28,13 @@ the `skipSuccessfulRequests` or `skipFailedRequests` options are enabled.
 The `init` method allows the store to set itself up using the options passed to
 the middleware. The store can get the `windowMs` option from this method.
 
+Starting with version 8.5.0, the `init` method may be async, and is a good place
+for things like opening a connection to a database or ensuring the schema is
+up-to-date. Errors & promise rejections from `init` will be caught and logged by
+express-rate-limit, but will not prevent other methods such as `increment()`
+from being called. Additionally, other methods such as `increment()` may be
+called before `init()` completes.
+
 The `get` method takes a `string` argument (the key that identifies a client)
 and returns an object consisting of the internal hit count (`totalHits`) and the
 time that the count will reach 0 (`resetTime`) for the given client. It may

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		"test:lib": "jest",
 		"test:ext": "cd test/external/ && bash run-all-tests",
 		"test": "run-s lint test:lib",
+		"format-test": "run-s format test:lib",
 		"pre-commit": "lint-staged",
 		"prepare": "run-s compile && husky"
 	},

--- a/source/rate-limit.ts
+++ b/source/rate-limit.ts
@@ -355,7 +355,19 @@ const rateLimit = (
 	config.validations.unsharedStore(config.store)
 
 	// Call the `init` method on the store, if it exists
-	if (typeof config.store.init === 'function') config.store.init(options)
+	if (typeof config.store.init === 'function') {
+		// If it returns a promise, we'll log any potential rejection error here
+		// Use .catch() rather than await, because we need to return synchronously
+		const storeInit = config.store.init(options)
+		if (storeInit instanceof Promise) {
+			storeInit.catch((error) =>
+				config.logger.error(
+					error,
+					'express-rate-limit: error during store initialization.',
+				),
+			)
+		}
+	}
 
 	// Then return the actual middleware
 	const middleware = handleAsyncErrors(

--- a/source/rate-limit.ts
+++ b/source/rate-limit.ts
@@ -356,15 +356,22 @@ const rateLimit = (
 
 	// Call the `init` method on the store, if it exists
 	if (typeof config.store.init === 'function') {
-		// If it returns a promise, we'll log any potential rejection error here
+		// If store.init() throws or rejects, we'll catch and log it
 		// Use .catch() rather than await, because we need to return synchronously
-		const storeInit = config.store.init(options)
-		if (storeInit instanceof Promise) {
-			storeInit.catch((error) =>
-				config.logger.error(
-					error,
-					'express-rate-limit: error during store initialization.',
-				),
+		try {
+			const storeInit = config.store.init(options)
+			if (storeInit instanceof Promise) {
+				storeInit.catch((error) =>
+					config.logger.error(
+						error,
+						'express-rate-limit: async error during store initialization.',
+					),
+				)
+			}
+		} catch (error) {
+			config.logger.error(
+				error,
+				'express-rate-limit: error during store initialization.',
 			)
 		}
 	}

--- a/source/types.ts
+++ b/source/types.ts
@@ -169,7 +169,6 @@ export type Store = {
 	 * Called once during initialization.
 	 *
 	 * Async errors / promise rejections will be caught and logged.
-	 * (Synchronously thrown errors are not caught, and will prevent the express-rate-limit instance from being created.)
 	 *
 	 * Note that the result is not awaited - other store methods (such as increment) may be called before init returns and/or after it rejects.
 	 *

--- a/source/types.ts
+++ b/source/types.ts
@@ -166,9 +166,16 @@ export type Store = {
 	 * Method that initializes the store, and has access to the options passed to
 	 * the middleware too.
 	 *
+	 * Called once during initialization.
+	 *
+	 * Async errors / promise rejections will be caught and logged.
+	 * (Synchronously thrown errors are not caught, and will prevent the express-rate-limit instance from being created.)
+	 *
+	 * Note that the result is not awaited - other store methods (such as increment) may be called before init returns and/or after it rejects.
+	 *
 	 * @param options {Options} - The options used to setup the middleware.
 	 */
-	init?: (options: Options) => void
+	init?: (options: Options) => void | Promise<void>
 
 	/**
 	 * Method to fetch a client's hit count and reset time.

--- a/source/types.ts
+++ b/source/types.ts
@@ -168,9 +168,9 @@ export type Store = {
 	 *
 	 * Called once during initialization.
 	 *
-	 * Async errors / promise rejections will be caught and logged.
+	 * Errors / promise rejections will be caught and logged.
 	 *
-	 * Note that the result is not awaited - other store methods (such as increment) may be called before init returns and/or after it rejects.
+	 * Note that the result is not awaited - other store methods (such as increment) may be called before init returns and/or after it throws/rejects.
 	 *
 	 * @param options {Options} - The options used to setup the middleware.
 	 */

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -4,7 +4,14 @@
 import { EventEmitter } from 'node:events'
 import { platform } from 'node:process'
 
-import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+} from '@jest/globals'
 import type { NextFunction, Request, Response } from 'express'
 import { agent as request } from 'supertest'
 import rateLimit, {
@@ -172,6 +179,67 @@ describe('middleware test', () => {
 		})
 
 		expect(store.initWasCalled).toEqual(true)
+	})
+
+	describe('async store init', () => {
+		let logger: Logger
+
+		beforeEach(() => {
+			logger = {
+				error: jest.fn(),
+				warn: jest.fn(),
+			}
+			jest.useRealTimers()
+		})
+
+		class MockStoreAsyncInitResolving extends MockStore {
+			initWasCalled = false
+
+			init(_options: Options): Promise<void> {
+				this.initWasCalled = true
+				return Promise.resolve()
+			}
+		}
+
+		class MockStoreAsyncInitRejecting extends MockStore {
+			initWasCalled = false
+
+			init(_options: Options): Promise<void> {
+				this.initWasCalled = true
+				return Promise.reject(new Error('Async init error'))
+			}
+		}
+
+		it('should handle resolving async init', async () => {
+			const store = new MockStoreAsyncInitResolving()
+			const limiter = rateLimit({
+				store,
+				logger,
+			})
+
+			await new Promise((resolve) => process.nextTick(resolve))
+
+			expect(limiter).not.toBeInstanceOf(Promise)
+			expect(store.initWasCalled).toEqual(true)
+			expect(logger.error).not.toHaveBeenCalled()
+		})
+
+		it('should handle rejecting async init and log error', async () => {
+			const store = new MockStoreAsyncInitRejecting()
+			const limiter = rateLimit({
+				store,
+				logger,
+			})
+
+			await new Promise((resolve) => process.nextTick(resolve))
+
+			expect(limiter).not.toBeInstanceOf(Promise)
+			expect(store.initWasCalled).toEqual(true)
+			expect(logger.error).toHaveBeenCalledWith(
+				expect.any(Error),
+				'express-rate-limit: error during store initialization.',
+			)
+		})
 	})
 
 	it('should let the first request through', async () => {

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -237,6 +237,23 @@ describe('middleware test', () => {
 			expect(store.initWasCalled).toEqual(true)
 			expect(logger.error).toHaveBeenCalledWith(
 				expect.any(Error),
+				'express-rate-limit: async error during store initialization.',
+			)
+		})
+
+		it('should catch synchronous errors thrown from store.init()', () => {
+			const store = new MockStore()
+			jest.spyOn(store, 'init').mockImplementation(() => {
+				throw new Error('test error')
+			})
+			const limiter = rateLimit({
+				store,
+				logger,
+			})
+
+			expect(limiter).not.toBeInstanceOf(Promise)
+			expect(logger.error).toHaveBeenCalledWith(
+				expect.any(Error),
 				'express-rate-limit: error during store initialization.',
 			)
 		})


### PR DESCRIPTION
This allows store init methods to be async / return a promise, and if it rejects, the error will be logged.

This is mainly to prevent unhandled rejections from store initialization that would otherwise take down the server. (Those could be recoverable if it's just a networking issue.) 

In particular, the redis store sends an early script upload, but it's able to retry that when handling requests, so it may recover later if the first upload fails.  But right now failures take down the server, so it doesn't get the opportunity to recover. (Also it sends the requests off in the constructor, but we'll move them to the init() method after this.)

Errors thrown synchronously are not caught (no change in behavior there), because I expect they generally wouldn't be recoverable. (And users can wrap their limiter creation in a try/catch if they believe it is a recoverable error.)

Relates to https://github.com/express-rate-limit/rate-limit-redis/issues/239 and https://github.com/express-rate-limit/express-rate-limit/issues/485

We could go farther and await the result before handling requests, but then I'm not sure what we'd do if it failed - try again, or allow/reject according to the `passOnStoreError` setting, or call store.increment() despite the failure? I think some of those might constitute breaking changes, and I think what's here is enough to handle the immediate need. So I think I want to just go with this more limited fix for now.