### PR TITLE
fix: bump ip-address to ^10.1.1 to resolve XSS vulnerability (GHSA-v2v4-37r5-5v8g)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"prepare": "run-s compile && husky"
 	},
 	"dependencies": {
-		"ip-address": "10.1.0"
+		"ip-address": "^10.1.1"
 	},
 	"peerDependencies": {
 		"express": ">= 4.11"


### PR DESCRIPTION
## Summary

Bump `ip-address` from a pinned `10.1.0` to a caret range `^10.1.1` to resolve [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) (XSS in Address6 HTML-emitting methods, severity: medium).

## Why a caret range instead of a fixed bump

The current pin (`"ip-address": "10.1.0"`) prevents downstream consumers from picking up patch-level fixes via `npm audit fix` / `pnpm install`. Downstream maintainers currently need to apply a local override just to get the fix.

Switching to `^10.1.1`:

- pulls in the immediate patch (10.1.1+)
- keeps future patch and minor updates flowing automatically (semver-compatible)
- lets future similar issues be resolved by consumers without an override or a new release of this package

## Closes

#624

## Test plan

- `pnpm install` resolves to a non-vulnerable `ip-address` version
- No source changes; only a dependency range adjustment