### PR TITLE
test: fix response closes skipFailedRequests (server) test

### DIFF
--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -4,7 +4,6 @@
 import { EventEmitter } from 'node:events'
 import HTTP from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { platform } from 'node:process'
 
 import {
 	afterEach,

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -2,6 +2,8 @@
 // Tests the rate limiting middleware
 
 import { EventEmitter } from 'node:events'
+import HTTP from 'node:http'
+import type { AddressInfo } from 'node:net'
 import { platform } from 'node:process'
 
 import {
@@ -722,22 +724,59 @@ describe('middleware test', () => {
 				}),
 			)
 
-			let _resolve: () => void
+			let received: () => void
+			const connectionOpened = new Promise<void>((resolve) => {
+				received = resolve
+			})
+			let closed: () => void
 			const connectionClosed = new Promise<void>((resolve) => {
-				_resolve = resolve
+				closed = resolve
+			})
+			app.get('/hang-server', (request, _response) => {
+				received()
+				request.on('close', closed)
 			})
 
-			app.get('/hang-server', (_request, response) => {
-				response.on('close', _resolve)
+			// starting with node.js v26.3.0, the supertest .timeout() method no longer works for this test, so we're skipping supertest and spinning up an actual http server and then making a request to it instead.
+			// see https://github.com/forwardemail/supertest/issues/891
+
+			let setListening: () => void
+			const listening = new Promise<void>((resolve) => {
+				setListening = resolve
 			})
+			const listener = app.listen((err) => {
+				if (err) {
+					console.error('Error starting server:', err)
+					throw err
+				}
+				setListening()
+			})
+			listener.unref() // don't keep the process from exiting if the test fails
+			await listening
 
-			// note: if the timeout is too short (e.g. 10ms), the test will sometimes fail on widows, presumably because it's timing out too quickly
-			const hangRequest = request(app).get('/hang-server').timeout(50)
+			const { address, port } = listener.address() as AddressInfo
+			expect(address).toBeDefined()
+			expect(port).toBeDefined()
 
-			await expect(hangRequest).rejects.toThrow()
+			const responseHandler = jest.fn()
+			// wrap address in [] because it's often an IPv6 address (which uses :'s instead of .'s to separate sections)
+			const hangRequest = HTTP.get(
+				`http://[${address}]:${port}/hang-server`,
+				responseHandler,
+			)
+
+			await connectionOpened
+
+			hangRequest.on('error', (_error) => {
+				/* expected, but if we don't add a listener, the test fails */
+			})
+			hangRequest.destroy()
+
 			await connectionClosed
+			listener.close() // shutdown the server
 
 			expect(store.decrementWasCalled).toEqual(true)
+			expect(responseHandler).not.toHaveBeenCalled() // this indicates we got a server response, which means something went wrong with this test
 		},
 	)
 

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -708,7 +708,7 @@ describe('middleware test', () => {
 		expect(store.decrementWasCalled).toEqual(true)
 	})
 
-	;(platform === 'darwin' ? it.skip : it).each([
+	it.each([
 		['modern', new MockStore()],
 		['legacy', new MockLegacyStore()],
 		['compat', new MockBackwardCompatibleStore()],

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -712,73 +712,70 @@ describe('middleware test', () => {
 		['modern', new MockStore()],
 		['legacy', new MockLegacyStore()],
 		['compat', new MockBackwardCompatibleStore()],
-	])(
-		'should decrement hits when response closes and `skipFailedRequests` is set to true (%s store) (server)',
-		async (name, store) => {
-			jest.useRealTimers()
+	])('should decrement hits when response closes and `skipFailedRequests` is set to true (%s store) (server)', async (name, store) => {
+		jest.useRealTimers()
 
-			const app = createServer(
-				rateLimit({
-					skipFailedRequests: true,
-					store,
-				}),
-			)
+		const app = createServer(
+			rateLimit({
+				skipFailedRequests: true,
+				store,
+			}),
+		)
 
-			let received: () => void
-			const connectionOpened = new Promise<void>((resolve) => {
-				received = resolve
-			})
-			let closed: () => void
-			const connectionClosed = new Promise<void>((resolve) => {
-				closed = resolve
-			})
-			app.get('/hang-server', (request, _response) => {
-				received()
-				request.on('close', closed)
-			})
+		let received: () => void
+		const connectionOpened = new Promise<void>((resolve) => {
+			received = resolve
+		})
+		let closed: () => void
+		const connectionClosed = new Promise<void>((resolve) => {
+			closed = resolve
+		})
+		app.get('/hang-server', (request, _response) => {
+			received()
+			request.on('close', closed)
+		})
 
-			// starting with node.js v26.3.0, the supertest .timeout() method no longer works for this test, so we're skipping supertest and spinning up an actual http server and then making a request to it instead.
-			// see https://github.com/forwardemail/supertest/issues/891
+		// starting with node.js v26.3.0, the supertest .timeout() method no longer works for this test, so we're skipping supertest and spinning up an actual http server and then making a request to it instead.
+		// see https://github.com/forwardemail/supertest/issues/891
 
-			let setListening: () => void
-			const listening = new Promise<void>((resolve) => {
-				setListening = resolve
-			})
-			const listener = app.listen((err) => {
-				if (err) {
-					console.error('Error starting server:', err)
-					throw err
-				}
-				setListening()
-			})
-			listener.unref() // don't keep the process from exiting if the test fails
-			await listening
+		let setListening: () => void
+		const listening = new Promise<void>((resolve) => {
+			setListening = resolve
+		})
+		const listener = app.listen((err) => {
+			if (err) {
+				console.error('Error starting server:', err)
+				throw err
+			}
+			setListening()
+		})
+		listener.unref() // don't keep the process from exiting if the test fails
+		await listening
 
-			const { address, port } = listener.address() as AddressInfo
-			expect(address).toBeDefined()
-			expect(port).toBeDefined()
+		const { address, port } = listener.address() as AddressInfo
+		expect(address).toBeDefined()
+		expect(port).toBeDefined()
 
-			const responseHandler = jest.fn()
-			// wrap address in [] because it's often an IPv6 address (which uses :'s instead of .'s to separate sections)
-			const hangRequest = HTTP.get(
-				`http://[${address}]:${port}/hang-server`,
-				responseHandler,
-			)
+		const responseHandler = jest.fn()
+		// wrap address in [] because it's often an IPv6 address (which uses :'s instead of .'s to separate sections)
+		const hangRequest = HTTP.get(
+			`http://[${address}]:${port}/hang-server`,
+			responseHandler,
+		)
 
-			await connectionOpened
+		await connectionOpened
 
-			hangRequest.on('error', (_error) => {
-				/* expected, but if we don't add a listener, the test fails */
-			})
-			hangRequest.destroy()
+		hangRequest.on('error', (_error) => {
+			/* expected, but if we don't add a listener, the test fails */
+		})
+		hangRequest.destroy()
 
-			await connectionClosed
-			listener.close() // shutdown the server
+		await connectionClosed
+		listener.close() // shutdown the server
 
-			expect(store.decrementWasCalled).toEqual(true)
-			expect(responseHandler).not.toHaveBeenCalled() // this indicates we got a server response, which means something went wrong with this test
-		},
-	)
+		expect(store.decrementWasCalled).toEqual(true)
+		expect(responseHandler).not.toHaveBeenCalled() // this indicates we got a server response, which means something went wrong with this test
+	})
 
 	it.each([
 		['modern', new MockStore()],


### PR DESCRIPTION
The `should decrement hits when response closes and 'skipFailedRequests' is set to true (%s store) (server)` test started [failing](https://github.com/express-rate-limit/express-rate-limit/actions/runs/26865003421/job/79581145692?pr=638) in node.js v26.3.0. I poked at it a bit and figured out that the supertest `.timeout(n)` method behaves differently in v26.3 - previously it would initiate the request and wait `n` milliseconds for the request to complete before aborting it. But now it aborts immediately, without even sending the request to the server.  (And, if you wait to call `.timeout(n)`, then it waits to initiate the request.) I filed a bug at https://github.com/forwardemail/supertest/issues/891 but didn't get to the bottom of it.

For our needs, I rewrote the test to spin up an actual server and use http.get to connect to it, then manually abort the request after the server receives it. This version of the test passes on all versions of node.js. 

What we're trying to test is the server-side behavior after a connection is aborted, so it doesn't really matter how the abort happens. (It probably wasn't a great fit for supertest to begin with, because that's more concerned with the client's perspective, so it doesn't care what happens after a request ends.)

It's kind of an awkward mix of promises and callbacks right now. We could probably clean that up, but I've spent a few evenings banging my head into this test already and I'm just ready to be done with it for now.

---

On an unrelated note, I kept seeing this line get logged:

> ts-jest[config] (WARN) message TS151002: Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json. To disable this message, you can set "diagnostics.ignoreCodes" to include 151002 in your ts-jest config. See more at https://kulshekhar.github.io/ts-jest/docs/getting-started/options/diagnostics

But, when I tried setting `isolatedModules: true`, it starts treating the tests as commonjs for some reason and fails on the first `import` statement in each file