### PR TITLE
fix: don't decrement if resetTime has passed

### DIFF
--- a/source/rate-limit.ts
+++ b/source/rate-limit.ts
@@ -507,6 +507,11 @@ const rateLimit = (
 					// This could have been tested properly if the response.on('error') test
 					// worked as well, leaving it as a todo.
 					if (!decremented) {
+						// Don't decrement if the reset time has already passed,
+						// as the store will have already reset the count for this key.
+						if (resetTime && Date.now() >= resetTime.getTime()) {
+							return
+						}
 						await config.store.decrement(key)
 						decremented = true
 					}

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -569,8 +569,6 @@ describe('middleware test', () => {
 	})
 
 	it('should decrement hits when request finishes before `resetTime` with `skipSuccessfulRequests`', async () => {
-		jest.useRealTimers()
-
 		const windowMs = 500
 		const requestDurationMs = 25
 		const store = new MockStore()
@@ -583,6 +581,7 @@ describe('middleware test', () => {
 			}),
 			(_request, _response, next) => {
 				setTimeout(next, requestDurationMs)
+				jest.runAllTimers()
 			},
 		])
 
@@ -592,8 +591,6 @@ describe('middleware test', () => {
 	})
 
 	it('should not decrement hits when request finishes after `resetTime` with `skipSuccessfulRequests`', async () => {
-		jest.useRealTimers()
-
 		const windowMs = 50
 		const requestDurationMs = 75
 		const store = new MockStore()
@@ -606,6 +603,7 @@ describe('middleware test', () => {
 			}),
 			(_request, _response, next) => {
 				setTimeout(next, requestDurationMs)
+				jest.runAllTimers()
 			},
 		])
 

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -43,11 +43,11 @@ describe('middleware test', () => {
 		resetAllWasCalled = false
 
 		counter = 0
+		windowMs = 0
 
-		constructor(private readonly resetInMS?: number) {}
-
-		init(_options: Options): void {
+		init(options: Options): void {
 			this.initWasCalled = true
+			this.windowMs = options.windowMs
 		}
 
 		async get(_key: string): Promise<ClientRateLimitInfo> {
@@ -62,10 +62,7 @@ describe('middleware test', () => {
 
 			return {
 				totalHits: this.counter,
-				resetTime:
-					typeof this.resetInMS === 'number'
-						? new Date(Date.now() + this.resetInMS)
-						: undefined,
+				resetTime: new Date(Date.now() + this.windowMs),
 			}
 		}
 
@@ -574,9 +571,9 @@ describe('middleware test', () => {
 	it('should decrement hits when request finishes before `resetTime` with `skipSuccessfulRequests`', async () => {
 		jest.useRealTimers()
 
-		const windowMs = 50
+		const windowMs = 500
 		const requestDurationMs = 25
-		const store = new MockStore(windowMs)
+		const store = new MockStore()
 
 		const app = createServer([
 			rateLimit({
@@ -599,7 +596,7 @@ describe('middleware test', () => {
 
 		const windowMs = 50
 		const requestDurationMs = 75
-		const store = new MockStore(windowMs)
+		const store = new MockStore()
 
 		const app = createServer([
 			rateLimit({

--- a/test/library/middleware-test.ts
+++ b/test/library/middleware-test.ts
@@ -44,6 +44,8 @@ describe('middleware test', () => {
 
 		counter = 0
 
+		constructor(private readonly resetInMS?: number) {}
+
 		init(_options: Options): void {
 			this.initWasCalled = true
 		}
@@ -58,7 +60,13 @@ describe('middleware test', () => {
 			this.counter += 1
 			this.incrementWasCalled = true
 
-			return { totalHits: this.counter, resetTime: undefined }
+			return {
+				totalHits: this.counter,
+				resetTime:
+					typeof this.resetInMS === 'number'
+						? new Date(Date.now() + this.resetInMS)
+						: undefined,
+			}
 		}
 
 		async decrement(_key: string): Promise<void> {
@@ -561,6 +569,52 @@ describe('middleware test', () => {
 		await request(app).get('/').expect(200)
 
 		expect(store.decrementWasCalled).toEqual(true)
+	})
+
+	it('should decrement hits when request finishes before `resetTime` with `skipSuccessfulRequests`', async () => {
+		jest.useRealTimers()
+
+		const windowMs = 50
+		const requestDurationMs = 25
+		const store = new MockStore(windowMs)
+
+		const app = createServer([
+			rateLimit({
+				skipSuccessfulRequests: true,
+				windowMs,
+				store,
+			}),
+			(_request, _response, next) => {
+				setTimeout(next, requestDurationMs)
+			},
+		])
+
+		await request(app).get('/').expect(200)
+
+		expect(store.decrementWasCalled).toEqual(true)
+	})
+
+	it('should not decrement hits when request finishes after `resetTime` with `skipSuccessfulRequests`', async () => {
+		jest.useRealTimers()
+
+		const windowMs = 50
+		const requestDurationMs = 75
+		const store = new MockStore(windowMs)
+
+		const app = createServer([
+			rateLimit({
+				skipSuccessfulRequests: true,
+				windowMs,
+				store,
+			}),
+			(_request, _response, next) => {
+				setTimeout(next, requestDurationMs)
+			},
+		])
+
+		await request(app).get('/').expect(200)
+
+		expect(store.decrementWasCalled).toEqual(false)
 	})
 
 	it.each([


### PR DESCRIPTION
We track use `express-rate-limit` and `rate-limit-redis` to apply a request concurrency limit, using the `skip*` options to decrement the number of “in flight” operations when a requests completes.  Within `windowMs`, the mechanism works as expected.  However, if a request starts in one window period and finishes after the counter is reset, the number of tracked “in-flight” requests can become negative.  The result is that more requests are allowed than expected.

One solution would be to set the Redis store `resetExpiryOnChange` parameter, but this would introduce the risk that a process crash never decrement the counter, leading to clients being unable to make requests within their allotment.

Another solution is to change the behaviour of `rate-limit-redis` to never allow counter to drop below 0, but this is difficult as we don’t know if the request in question is one which has crossed the reset boundary.

The best approach I could identify was to update the behaviour of the `decrement()` call so that the counter remains unchanged if the completion time has progressed beyond that of when the counter would be reset.

However, this does introduce the risk that if the user configured `resetExpiryOnChange`, a decrement is not performed when it it would in fact be valid.  I was unsure how you would prefer to resolve the conflict, given the that stores may handle this differently.  Is changing the store interface ok, or should the change in decrement behaviour be configurable?