### PR TITLE
Fix typo in express-rate-limit usage section

### DIFF
--- a/docs/quickstart/usage.mdx
+++ b/docs/quickstart/usage.mdx
@@ -90,8 +90,8 @@ troubleshooting proxy issues.
 Although not officially supported, several individuals have been able to
 successfully use express-rate-limit in [Next.js](https://nextjs.org/) by
 defining a custom [`keyGenerator`](/reference/configuration#keygenerator) to
-return the user's IP (or some other identifier). However, additional changes
-changes are sometimes needed, such as
+return the user's IP (or some other identifier). However, additional changes are
+sometimes needed, such as
 [handling schema migrations with rate-limit-postgresql](https://github.com/express-rate-limit/rate-limit-postgresql/issues/36).
 
 ### Using External Stores


### PR DESCRIPTION
Corrected a typo in the usage documentation regarding express-rate-limit. Removed the extra 'changes' word.