### PR TITLE
feat: add retryAfter option

### DIFF
--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -281,6 +281,37 @@ the Express `req` and `res` objects and then returns a string.
 Defaults to a function that returns a string of the format
 `{limit}-in-{window}`, e.g., `7-in-1.5sec`.
 
+## `retryAfter`
+
+> `number | function`
+
+Custom value (in seconds) for the `Retry-After` header sent when a client is
+rate limited.
+
+Can be the value itself as a number or a (sync/async) function that accepts the
+Express `req` and `res` objects and then returns a number.
+
+<Note>
+
+This is advisory only. It changes what the `Retry-After` header says, it does
+not change how long the limiter actually keeps blocking the client for. That is
+still controlled by [`windowMs`](#windowms).
+
+</Note>
+
+By default, the number of seconds remaining until the window resets.
+
+```ts
+const limiter = rateLimit({
+	// ...
+	retryAfter: async (req, res) => {
+		// e.g. always tell clients to back off for a fixed 10 minutes,
+		// regardless of how the window is configured.
+		return 10 * 60
+	},
+})
+```
+
 ## `store`
 
 > `Store`

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -307,7 +307,7 @@ const limiter = rateLimit({
 	retryAfter: async (req, res) => {
 		// e.g. always tell clients to back off for a fixed 10 minutes,
 		// regardless of how the window is configured.
-		return 10 * 60
+		return 10 * 60 // seconds, unlike windowMs
 	},
 })
 ```

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -281,15 +281,21 @@ the Express `req` and `res` objects and then returns a string.
 Defaults to a function that returns a string of the format
 `{limit}-in-{window}`, e.g., `7-in-1.5sec`.
 
-## `retryAfter`
+## `retryAfterMs`
 
 > `number | function`
 
-Custom value (in seconds) for the `Retry-After` header sent when a client is
-rate limited.
+Custom value, in milliseconds, used to compute the `Retry-After` header sent
+when a client is rate limited. Uses the same unit as [`windowMs`](#windowms) and
+the `DAY`/`HOUR`/`MINUTE`/`SECOND` constants.
 
 Can be the value itself as a number or a (sync/async) function that accepts the
 Express `req` and `res` objects and then returns a number.
+
+When set, the value is added to the current time and sent as an
+[HTTP-date](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After#syntax)
+rather than a plain delay in seconds, since HTTP dates don't carry millisecond
+precision, the header may be off by up to a second from the exact value given.
 
 <Note>
 
@@ -299,15 +305,18 @@ still controlled by [`windowMs`](#windowms).
 
 </Note>
 
-By default, the number of seconds remaining until the window resets.
+By default, this is unset, and the header instead reports the number of seconds
+remaining until the window resets.
 
 ```ts
+import { rateLimit, MINUTE } from 'express-rate-limit'
+
 const limiter = rateLimit({
 	// ...
-	retryAfter: async (req, res) => {
+	retryAfterMs: async (req, res) => {
 		// e.g. always tell clients to back off for a fixed 10 minutes,
 		// regardless of how the window is configured.
-		return 10 * 60
+		return 10 * MINUTE
 	},
 })
 ```

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -281,21 +281,15 @@ the Express `req` and `res` objects and then returns a string.
 Defaults to a function that returns a string of the format
 `{limit}-in-{window}`, e.g., `7-in-1.5sec`.
 
-## `retryAfterMs`
+## `retryAfter`
 
 > `number | function`
 
-Custom value, in milliseconds, used to compute the `Retry-After` header sent
-when a client is rate limited. Uses the same unit as [`windowMs`](#windowms) and
-the `DAY`/`HOUR`/`MINUTE`/`SECOND` constants.
+Custom value (in seconds) for the `Retry-After` header sent when a client is
+rate limited.
 
 Can be the value itself as a number or a (sync/async) function that accepts the
 Express `req` and `res` objects and then returns a number.
-
-When set, the value is added to the current time and sent as an
-[HTTP-date](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After#syntax)
-rather than a plain delay in seconds, since HTTP dates don't carry millisecond
-precision, the header may be off by up to a second from the exact value given.
 
 <Note>
 
@@ -305,18 +299,15 @@ still controlled by [`windowMs`](#windowms).
 
 </Note>
 
-By default, this is unset, and the header instead reports the number of seconds
-remaining until the window resets.
+By default, the number of seconds remaining until the window resets.
 
 ```ts
-import { rateLimit, MINUTE } from 'express-rate-limit'
-
 const limiter = rateLimit({
 	// ...
-	retryAfterMs: async (req, res) => {
+	retryAfter: async (req, res) => {
 		// e.g. always tell clients to back off for a fixed 10 minutes,
 		// regardless of how the window is configured.
-		return 10 * MINUTE
+		return 10 * 60
 	},
 })
 ```

--- a/source/headers.ts
+++ b/source/headers.ts
@@ -163,14 +163,16 @@ export const setDraft8Headers = (
  * @param response {Response} - The express response object to set headers on.
  * @param info {RateLimitInfo} - The rate limit info, used to set the headers.
  * @param windowMs {number} - The window length.
+ * @param retryAfter {number} - Custom override for the header value, in seconds. Falls back to the window's reset time if not given.
  */
 export const setRetryAfterHeader = (
 	response: Response,
 	info: RateLimitInfo,
 	windowMs: number,
+	retryAfter?: number,
 ): void => {
 	if (response.headersSent) return
 
-	const resetSeconds = getResetSeconds(windowMs, info.resetTime)
+	const resetSeconds = retryAfter ?? getResetSeconds(windowMs, info.resetTime)
 	response.setHeader('Retry-After', resetSeconds.toString())
 }

--- a/source/headers.ts
+++ b/source/headers.ts
@@ -160,19 +160,33 @@ export const setDraft8Headers = (
 /**
  * Sets the `Retry-After` header.
  *
+ * If a custom `retryAfterMs` is given, it is added to the current time and
+ * sent as an HTTP-date, since `retryAfterMs` is in milliseconds while the
+ * default delay-in-seconds form would require converting units. Otherwise,
+ * falls back to the existing delay-in-seconds behavior based on the window's
+ * reset time.
+ *
  * @param response {Response} - The express response object to set headers on.
  * @param info {RateLimitInfo} - The rate limit info, used to set the headers.
  * @param windowMs {number} - The window length.
- * @param retryAfter {number} - Custom override for the header value, in seconds. Falls back to the window's reset time if not given.
+ * @param retryAfterMs {number} - Custom override for the header value, in milliseconds from now.
  */
 export const setRetryAfterHeader = (
 	response: Response,
 	info: RateLimitInfo,
 	windowMs: number,
-	retryAfter?: number,
+	retryAfterMs?: number,
 ): void => {
 	if (response.headersSent) return
 
-	const resetSeconds = retryAfter ?? getResetSeconds(windowMs, info.resetTime)
-	response.setHeader('Retry-After', resetSeconds.toString())
+	if (retryAfterMs === undefined) {
+		const resetSeconds = getResetSeconds(windowMs, info.resetTime)
+		response.setHeader('Retry-After', resetSeconds.toString())
+		return
+	}
+
+	response.setHeader(
+		'Retry-After',
+		new Date(Date.now() + retryAfterMs).toUTCString(),
+	)
 }

--- a/source/headers.ts
+++ b/source/headers.ts
@@ -160,33 +160,19 @@ export const setDraft8Headers = (
 /**
  * Sets the `Retry-After` header.
  *
- * If a custom `retryAfterMs` is given, it is added to the current time and
- * sent as an HTTP-date, since `retryAfterMs` is in milliseconds while the
- * default delay-in-seconds form would require converting units. Otherwise,
- * falls back to the existing delay-in-seconds behavior based on the window's
- * reset time.
- *
  * @param response {Response} - The express response object to set headers on.
  * @param info {RateLimitInfo} - The rate limit info, used to set the headers.
  * @param windowMs {number} - The window length.
- * @param retryAfterMs {number} - Custom override for the header value, in milliseconds from now.
+ * @param retryAfter {number} - Custom override for the header value, in seconds. Falls back to the window's reset time if not given.
  */
 export const setRetryAfterHeader = (
 	response: Response,
 	info: RateLimitInfo,
 	windowMs: number,
-	retryAfterMs?: number,
+	retryAfter?: number,
 ): void => {
 	if (response.headersSent) return
 
-	if (retryAfterMs === undefined) {
-		const resetSeconds = getResetSeconds(windowMs, info.resetTime)
-		response.setHeader('Retry-After', resetSeconds.toString())
-		return
-	}
-
-	response.setHeader(
-		'Retry-After',
-		new Date(Date.now() + retryAfterMs).toUTCString(),
-	)
+	const resetSeconds = retryAfter ?? getResetSeconds(windowMs, info.resetTime)
+	response.setHeader('Retry-After', resetSeconds.toString())
 }

--- a/source/rate-limit.ts
+++ b/source/rate-limit.ts
@@ -114,6 +114,7 @@ type Configuration = {
 	legacyHeaders: boolean
 	standardHeaders: false | DraftHeadersVersion
 	identifier: string | ValueDeterminingMiddleware<string>
+	retryAfter?: number | ValueDeterminingMiddleware<number>
 	requestPropertyName: string
 	skipFailedRequests: boolean
 	skipSuccessfulRequests: boolean
@@ -598,7 +599,12 @@ const rateLimit = (
 				debug('limit exceeded')
 				if (config.legacyHeaders || config.standardHeaders) {
 					debug('set retry-after header')
-					setRetryAfterHeader(response, info, config.windowMs)
+					const retrieveRetryAfter =
+						typeof config.retryAfter === 'function'
+							? config.retryAfter(request, response)
+							: config.retryAfter
+					const retryAfter = await retrieveRetryAfter
+					setRetryAfterHeader(response, info, config.windowMs, retryAfter)
 				}
 
 				config.handler(request, response, next, options)

--- a/source/rate-limit.ts
+++ b/source/rate-limit.ts
@@ -114,7 +114,7 @@ type Configuration = {
 	legacyHeaders: boolean
 	standardHeaders: false | DraftHeadersVersion
 	identifier: string | ValueDeterminingMiddleware<string>
-	retryAfter?: number | ValueDeterminingMiddleware<number>
+	retryAfterMs?: number | ValueDeterminingMiddleware<number>
 	requestPropertyName: string
 	skipFailedRequests: boolean
 	skipSuccessfulRequests: boolean
@@ -599,12 +599,12 @@ const rateLimit = (
 				debug('limit exceeded')
 				if (config.legacyHeaders || config.standardHeaders) {
 					debug('set retry-after header')
-					const retrieveRetryAfter =
-						typeof config.retryAfter === 'function'
-							? config.retryAfter(request, response)
-							: config.retryAfter
-					const retryAfter = await retrieveRetryAfter
-					setRetryAfterHeader(response, info, config.windowMs, retryAfter)
+					const retrieveRetryAfterMs =
+						typeof config.retryAfterMs === 'function'
+							? config.retryAfterMs(request, response)
+							: config.retryAfterMs
+					const retryAfterMs = await retrieveRetryAfterMs
+					setRetryAfterHeader(response, info, config.windowMs, retryAfterMs)
 				}
 
 				config.handler(request, response, next, options)

--- a/source/rate-limit.ts
+++ b/source/rate-limit.ts
@@ -114,7 +114,7 @@ type Configuration = {
 	legacyHeaders: boolean
 	standardHeaders: false | DraftHeadersVersion
 	identifier: string | ValueDeterminingMiddleware<string>
-	retryAfterMs?: number | ValueDeterminingMiddleware<number>
+	retryAfter?: number | ValueDeterminingMiddleware<number>
 	requestPropertyName: string
 	skipFailedRequests: boolean
 	skipSuccessfulRequests: boolean
@@ -599,12 +599,12 @@ const rateLimit = (
 				debug('limit exceeded')
 				if (config.legacyHeaders || config.standardHeaders) {
 					debug('set retry-after header')
-					const retrieveRetryAfterMs =
-						typeof config.retryAfterMs === 'function'
-							? config.retryAfterMs(request, response)
-							: config.retryAfterMs
-					const retryAfterMs = await retrieveRetryAfterMs
-					setRetryAfterHeader(response, info, config.windowMs, retryAfterMs)
+					const retrieveRetryAfter =
+						typeof config.retryAfter === 'function'
+							? config.retryAfter(request, response)
+							: config.retryAfter
+					const retryAfter = await retrieveRetryAfter
+					setRetryAfterHeader(response, info, config.windowMs, retryAfter)
 				}
 
 				config.handler(request, response, next, options)

--- a/source/types.ts
+++ b/source/types.ts
@@ -313,6 +313,18 @@ export type Options = {
 	identifier: string | ValueDeterminingMiddleware<string>
 
 	/**
+	 * Method to generate a custom `Retry-After` header value (in seconds) when
+	 * a client is rate limited.
+	 *
+	 * This is advisory only, it customizes what the header says, it does not
+	 * change how long the limiter actually keeps blocking the client for.
+	 * That is still controlled by `windowMs`.
+	 *
+	 * By default, the number of seconds remaining until the window resets.
+	 */
+	retryAfter?: number | ValueDeterminingMiddleware<number>
+
+	/**
 	 * The name of the property on the request object to store the rate limit info.
 	 *
 	 * Defaults to `rateLimit`.

--- a/source/types.ts
+++ b/source/types.ts
@@ -313,16 +313,22 @@ export type Options = {
 	identifier: string | ValueDeterminingMiddleware<string>
 
 	/**
-	 * Method to generate a custom `Retry-After` header value (in seconds) when
-	 * a client is rate limited.
+	 * Method to generate a custom `Retry-After` header value, in milliseconds,
+	 * when a client is rate limited. Matches the units used by `windowMs` and
+	 * the `DAY`/`HOUR`/`MINUTE`/`SECOND` constants.
+	 *
+	 * When set, the number is added to the current time and sent as an
+	 * HTTP-date (rather than a plain delay-in-seconds), since the `Retry-After`
+	 * header supports both forms.
 	 *
 	 * This is advisory only, it customizes what the header says, it does not
 	 * change how long the limiter actually keeps blocking the client for.
 	 * That is still controlled by `windowMs`.
 	 *
-	 * By default, the number of seconds remaining until the window resets.
+	 * By default, the number of seconds remaining until the window resets is
+	 * sent instead.
 	 */
-	retryAfter?: number | ValueDeterminingMiddleware<number>
+	retryAfterMs?: number | ValueDeterminingMiddleware<number>
 
 	/**
 	 * The name of the property on the request object to store the rate limit info.

--- a/source/types.ts
+++ b/source/types.ts
@@ -313,22 +313,16 @@ export type Options = {
 	identifier: string | ValueDeterminingMiddleware<string>
 
 	/**
-	 * Method to generate a custom `Retry-After` header value, in milliseconds,
-	 * when a client is rate limited. Matches the units used by `windowMs` and
-	 * the `DAY`/`HOUR`/`MINUTE`/`SECOND` constants.
-	 *
-	 * When set, the number is added to the current time and sent as an
-	 * HTTP-date (rather than a plain delay-in-seconds), since the `Retry-After`
-	 * header supports both forms.
+	 * Method to generate a custom `Retry-After` header value (in seconds) when
+	 * a client is rate limited.
 	 *
 	 * This is advisory only, it customizes what the header says, it does not
 	 * change how long the limiter actually keeps blocking the client for.
 	 * That is still controlled by `windowMs`.
 	 *
-	 * By default, the number of seconds remaining until the window resets is
-	 * sent instead.
+	 * By default, the number of seconds remaining until the window resets.
 	 */
-	retryAfterMs?: number | ValueDeterminingMiddleware<number>
+	retryAfter?: number | ValueDeterminingMiddleware<number>
 
 	/**
 	 * The name of the property on the request object to store the rate limit info.

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -327,6 +327,7 @@ const validations = {
 			legacyHeaders: true,
 			standardHeaders: true,
 			identifier: true,
+			retryAfter: true,
 			requestPropertyName: true,
 			skipFailedRequests: true,
 			skipSuccessfulRequests: true,

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -327,7 +327,7 @@ const validations = {
 			legacyHeaders: true,
 			standardHeaders: true,
 			identifier: true,
-			retryAfterMs: true,
+			retryAfter: true,
 			requestPropertyName: true,
 			skipFailedRequests: true,
 			skipSuccessfulRequests: true,

--- a/source/validations.ts
+++ b/source/validations.ts
@@ -327,7 +327,7 @@ const validations = {
 			legacyHeaders: true,
 			standardHeaders: true,
 			identifier: true,
-			retryAfter: true,
+			retryAfterMs: true,
 			requestPropertyName: true,
 			skipFailedRequests: true,
 			skipSuccessfulRequests: true,

--- a/test/library/headers-test.ts
+++ b/test/library/headers-test.ts
@@ -175,6 +175,32 @@ describe('headers test', () => {
 		await request(app).get('/').expect(429).expect('retry-after', '60')
 	})
 
+	it('should use the `retryAfter` option as the `retry-after` header value when set to a number', async () => {
+		const app = createServer(
+			rateLimit({
+				windowMs: 60 * 1000,
+				limit: 1,
+				retryAfter: 600,
+			}),
+		)
+
+		await request(app).get('/').expect(200)
+		await request(app).get('/').expect(429).expect('retry-after', '600')
+	})
+
+	it('should use the `retryAfter` option as the `retry-after` header value when set to a function', async () => {
+		const app = createServer(
+			rateLimit({
+				windowMs: 60 * 1000,
+				limit: 1,
+				retryAfter: async (_request, _response) => 600,
+			}),
+		)
+
+		await request(app).get('/').expect(200)
+		await request(app).get('/').expect(429).expect('retry-after', '600')
+	})
+
 	it('should not set the `retry-after` header if all headers have been disabled', async () => {
 		const app = createServer(
 			rateLimit({

--- a/test/library/headers-test.ts
+++ b/test/library/headers-test.ts
@@ -175,30 +175,44 @@ describe('headers test', () => {
 		await request(app).get('/').expect(429).expect('retry-after', '60')
 	})
 
-	it('should use the `retryAfter` option as the `retry-after` header value when set to a number', async () => {
+	it('should use the `retryAfterMs` option to send the `retry-after` header as an http-date when set to a number', async () => {
 		const app = createServer(
 			rateLimit({
 				windowMs: 60 * 1000,
 				limit: 1,
-				retryAfter: 600,
+				retryAfterMs: 10 * 60 * 1000, // 10 minutes
 			}),
 		)
 
 		await request(app).get('/').expect(200)
-		await request(app).get('/').expect(429).expect('retry-after', '600')
+		const before = Date.now()
+		const response = await request(app).get('/').expect(429)
+
+		const retryAfterMs = new Date(
+			response.get('retry-after') as string,
+		).getTime()
+		expect(retryAfterMs).toBeGreaterThanOrEqual(before + 10 * 60 * 1000 - 2000)
+		expect(retryAfterMs).toBeLessThanOrEqual(before + 10 * 60 * 1000 + 2000)
 	})
 
-	it('should use the `retryAfter` option as the `retry-after` header value when set to a function', async () => {
+	it('should use the `retryAfterMs` option to send the `retry-after` header as an http-date when set to a function', async () => {
 		const app = createServer(
 			rateLimit({
 				windowMs: 60 * 1000,
 				limit: 1,
-				retryAfter: async (_request, _response) => 600,
+				retryAfterMs: async (_request, _response) => 10 * 60 * 1000,
 			}),
 		)
 
 		await request(app).get('/').expect(200)
-		await request(app).get('/').expect(429).expect('retry-after', '600')
+		const before = Date.now()
+		const response = await request(app).get('/').expect(429)
+
+		const retryAfterMs = new Date(
+			response.get('retry-after') as string,
+		).getTime()
+		expect(retryAfterMs).toBeGreaterThanOrEqual(before + 10 * 60 * 1000 - 2000)
+		expect(retryAfterMs).toBeLessThanOrEqual(before + 10 * 60 * 1000 + 2000)
 	})
 
 	it('should not set the `retry-after` header if all headers have been disabled', async () => {

--- a/test/library/headers-test.ts
+++ b/test/library/headers-test.ts
@@ -175,44 +175,30 @@ describe('headers test', () => {
 		await request(app).get('/').expect(429).expect('retry-after', '60')
 	})
 
-	it('should use the `retryAfterMs` option to send the `retry-after` header as an http-date when set to a number', async () => {
+	it('should use the `retryAfter` option as the `retry-after` header value when set to a number', async () => {
 		const app = createServer(
 			rateLimit({
 				windowMs: 60 * 1000,
 				limit: 1,
-				retryAfterMs: 10 * 60 * 1000, // 10 minutes
+				retryAfter: 600,
 			}),
 		)
 
 		await request(app).get('/').expect(200)
-		const before = Date.now()
-		const response = await request(app).get('/').expect(429)
-
-		const retryAfterMs = new Date(
-			response.get('retry-after') as string,
-		).getTime()
-		expect(retryAfterMs).toBeGreaterThanOrEqual(before + 10 * 60 * 1000 - 2000)
-		expect(retryAfterMs).toBeLessThanOrEqual(before + 10 * 60 * 1000 + 2000)
+		await request(app).get('/').expect(429).expect('retry-after', '600')
 	})
 
-	it('should use the `retryAfterMs` option to send the `retry-after` header as an http-date when set to a function', async () => {
+	it('should use the `retryAfter` option as the `retry-after` header value when set to a function', async () => {
 		const app = createServer(
 			rateLimit({
 				windowMs: 60 * 1000,
 				limit: 1,
-				retryAfterMs: async (_request, _response) => 10 * 60 * 1000,
+				retryAfter: async (_request, _response) => 600,
 			}),
 		)
 
 		await request(app).get('/').expect(200)
-		const before = Date.now()
-		const response = await request(app).get('/').expect(429)
-
-		const retryAfterMs = new Date(
-			response.get('retry-after') as string,
-		).getTime()
-		expect(retryAfterMs).toBeGreaterThanOrEqual(before + 10 * 60 * 1000 - 2000)
-		expect(retryAfterMs).toBeLessThanOrEqual(before + 10 * 60 * 1000 + 2000)
+		await request(app).get('/').expect(429).expect('retry-after', '600')
 	})
 
 	it('should not set the `retry-after` header if all headers have been disabled', async () => {


### PR DESCRIPTION
Closes #441.

Adds a retryAfter option that lets you customize the Retry-After header value sent on a 429 response. Can be a number or a (sync/async) function, matching the pattern already used for limit/message/identifier.

This only covers the advisory piece of the original request. As discussed in the thread, actually enforcing a longer block period (the "cool down period" idea) would need changes to how every store handles resets, so that part is out of scope here. This just changes what the header says, not how long the limiter keeps blocking.

Scoped narrowly to the plain Retry-After header. Doesn't touch the RateLimit-Reset value inside the draft-6/7/8 standardHeaders, since that represents the window's reset time (sent on every response) rather than a cooldown that only applies after a block (sent only on 429s), a different concept.

Made the option optional rather than giving it a forced default function. The natural default needs info.resetTime, which isn't available to a function shaped like the other options, (request, response) => value. 
Falls back to the existing reset time calculation when unset, so no behavior change for anyone not using it.

Added two tests (number and function forms) plus a docs section under Configuration.

Let me know if I've misread the intended scope anywhere.