### PR TITLE
chore: deprecate millisecond-based time constants

### DIFF
--- a/docs/reference/changelog.mdx
+++ b/docs/reference/changelog.mdx
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.6.1](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v8.6.1)
+
+### Changed
+
+- Deprecated time constants added in previous release (`DAY`, `HOUR`, `MINUTE`,
+  and `SECOND`)
+  - These will be replaced by a slightly different version in the next major
+    release
+
 ## [8.6.0](https://github.com/express-rate-limit/express-rate-limit/releases/tag/v8.6.0)
 
 ### Fixed

--- a/readme.md
+++ b/readme.md
@@ -21,10 +21,10 @@ The [full documentation](https://express-rate-limit.mintlify.app/overview) is
 available on-line.
 
 ```ts
-import { rateLimit, MINUTE } from 'express-rate-limit'
+import { rateLimit } from 'express-rate-limit'
 
 const limiter = rateLimit({
-	windowMs: 15 * MINUTE, // SECOND, MINUTE, HOUR, and DAY constants are available, or a use bare number for milliseconds
+	windowMs: 15 * 60 * 1000, // 15 minutes
 	limit: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes).
 	standardHeaders: 'draft-8', // draft-6: `RateLimit-*` headers; draft-7 & draft-8: combined `RateLimit` header
 	legacyHeaders: false, // Disable the `X-RateLimit-*` headers.

--- a/source/time-constants.ts
+++ b/source/time-constants.ts
@@ -1,20 +1,19 @@
 /**
- * Time constants in milliseconds
- *
- * Use these with rate limit window calculations:
- * @example
- * // 5 minute window
- * windowMs: 5 * MINUTE
- *
- * // 2 hour window
- * windowMs: 2 * HOUR
- *
- * // 1 day window
- * windowMs: 1 * DAY
- *
  * @deprecated these are being replaced in the next major version
  */
 export const SECOND: number = 1000
+
+/**
+ * @deprecated these are being replaced in the next major version
+ */
 export const MINUTE: number = 60 * SECOND
+
+/**
+ * @deprecated these are being replaced in the next major version
+ */
 export const HOUR: number = 60 * MINUTE
+
+/**
+ * @deprecated these are being replaced in the next major version
+ */
 export const DAY: number = 24 * HOUR

--- a/source/time-constants.ts
+++ b/source/time-constants.ts
@@ -11,6 +11,8 @@
  *
  * // 1 day window
  * windowMs: 1 * DAY
+ *
+ * @deprecated these are being replaced in the next major version
  */
 export const SECOND: number = 1000
 export const MINUTE: number = 60 * SECOND


### PR DESCRIPTION
We're going to remove these in the next major release and replace them with a slightly different variation that's based on seconds rather than milliseconds.

See discussion on https://github.com/express-rate-limit/express-rate-limit/pull/661 and also previous work at https://github.com/express-rate-limit/express-rate-limit/pull/655