### PR TITLE
fix: key IPv4-in-IPv6 addresses by range, not notation

### DIFF
--- a/docs/reference/helpers.mdx
+++ b/docs/reference/helpers.mdx
@@ -15,6 +15,10 @@ icon: 'puzzle-piece'
 notation. (Unless second parameter is `false`, then IPv6 is also returned
 unchanged).
 
+IPv4-mapped IPv6 addresses (the `::ffff:0:0/96` range, commonly seen on
+dual-stack servers) are returned as the IPv4 address they contain, whichever
+notation they arrive in.
+
 This method is used by the default
 [`keyGenerator`](./configuration#keygenerator) to apply the configured
 [`ipv6Subnet`](./configuration#ipv6subnet), in order to properly rate-limit IPv6

--- a/source/ip-key-generator.ts
+++ b/source/ip-key-generator.ts
@@ -1,6 +1,11 @@
 import { isIPv6 } from 'node:net'
 import { Address6 } from 'ip-address'
 
+// The deprecated IPv4-compatible range (RFC 4291, section 2.5.5.1). The
+// IPv4-mapped range is recognized with `isMapped4()`, which needs no comparison
+// subnet.
+const ipv4CompatibleSubnet = new Address6('::/96')
+
 /**
  * Returns the IP address itself for IPv4, or a CIDR-notation subnet for IPv6.
  *
@@ -25,7 +30,23 @@ export function ipKeyGenerator(ip: string, ipv6Subnet: number | false = 56) {
 		// this is the case, we extract and return the IPv4 address. Otherwise, the
 		// default subnet value of 56 (or any 32 to 80 subnet) ignores the unique IP
 		// address in the last two octets completely.
-		if (address.is4()) return address.to4().correctForm()
+		//
+		// Whether an address is mapped has to be decided from its bits
+		// (`isMapped4()`) rather than from its notation (`is4()`), because those are
+		// different questions: `::ffff:1.2.3.4` and `::ffff:102:304` are one address
+		// written two ways and must produce one key, while `2001:db8::1.2.3.4` is an
+		// ordinary IPv6 address that merely ends in dotted-quad notation. Extracting
+		// `1.2.3.4` from the latter would skip the subnet entirely and key the client
+		// on the bits it controls itself, as well as put it in the same bucket as the
+		// unrelated IPv4 client 1.2.3.4.
+		if (
+			address.isMapped4() ||
+			// The deprecated IPv4-compatible notation keeps its existing behavior.
+			// Its range is shared with addresses that embed no IPv4 address at all
+			// (`::`, `::1`), so here the notation is what tells them apart.
+			(address.is4() && address.isInSubnet(ipv4CompatibleSubnet))
+		)
+			return address.to4().correctForm()
 
 		// For IPv6, return the network address of the subnet in CIDR format
 		if (ipv6Subnet) {

--- a/test/library/ip-key-generator-test.ts
+++ b/test/library/ip-key-generator-test.ts
@@ -11,6 +11,38 @@ describe('ipKeyGenerator', () => {
 		expect(ipKeyGenerator('::1.2.3.4')).toBe('1.2.3.4')
 	})
 
+	it('should return an IPv4 address mapped to IPv6 as an IPv4 address regardless of notation', () => {
+		// `::ffff:102:304` and `::ffff:1.2.3.4` are one address written two ways, so
+		// they have to produce one key.
+		expect(ipKeyGenerator('::ffff:102:304')).toBe('1.2.3.4')
+		expect(ipKeyGenerator('::ffff:102:304', 16)).toBe('1.2.3.4')
+		expect(ipKeyGenerator('::ffff:102:304', false)).toBe('1.2.3.4')
+		expect(ipKeyGenerator('::ffff:102:304')).toBe(
+			ipKeyGenerator('::ffff:1.2.3.4'),
+		)
+	})
+
+	it('should apply ipv6Subnet to an IPv6 address that merely ends in dotted-quad notation', () => {
+		// These are ordinary IPv6 addresses that only look IPv4-mapped. Extracting
+		// the trailing IPv4 address would key the client on the bits it controls
+		// itself, and put it in the same bucket as an unrelated IPv4 client.
+		expect(ipKeyGenerator('2001:db8:1234:5678::1.2.3.4')).toBe(
+			'2001:db8:1234:5600::/56',
+		)
+		expect(ipKeyGenerator('64:ff9b::1.2.3.4')).toBe('64:ff9b::/56')
+		expect(ipKeyGenerator('2001:db8:1234:5678::1.2.3.4')).toBe(
+			ipKeyGenerator('2001:db8:1234:5678::102:304'),
+		)
+		expect(ipKeyGenerator('2001:db8::1.2.3.4')).not.toBe(
+			ipKeyGenerator('1.2.3.4'),
+		)
+	})
+
+	it('should apply ipv6Subnet to addresses in the IPv4-compatible range that are not written in dotted-quad notation', () => {
+		expect(ipKeyGenerator('::1')).toBe('::/56')
+		expect(ipKeyGenerator('::')).toBe('::/56')
+	})
+
 	it('should return an IPv6 address unchanged with ipv6Subnet set to false', () => {
 		expect(
 			ipKeyGenerator('0123:4567:89ab:cdef:0123:4567:89ab:cdef', false),


### PR DESCRIPTION
## The problem

`ipKeyGenerator` decides whether an IPv6 address embeds an IPv4 address with
`Address6.is4()`. That method answers a different question than the one being
asked: it reports whether the address was *written* in v4-in-v6 dotted-quad
notation, not whether its bits fall in the IPv4-mapped range. `ip-address`
documents it as "a notation-level flag [that] does not reflect whether the
address bits lie in the IPv4-mapped (`::ffff:0:0/96`) subnet".

Two things follow from that, in opposite directions:

| `ip` | current key | expected |
| --- | --- | --- |
| `::ffff:1.2.3.4` | `1.2.3.4` | `1.2.3.4` |
| `::ffff:102:304` (same address) | `::/56` | `1.2.3.4` |
| `2001:db8:1234:5678::1.2.3.4` | `1.2.3.4` | `2001:db8:1234:5600::/56` |
| `2001:db8:1234:5678::102:304` (same address) | `2001:db8:1234:5600::/56` | unchanged |
| `64:ff9b::1.2.3.4` | `1.2.3.4` | `64:ff9b::/56` |

1. **A mapped address written without a dotted quad isn't recognized**, so the
   /56 subnet is applied to it and it collapses to `::/56` — one bucket shared
   with every other address in that range.
2. **An ordinary IPv6 address that merely ends in a dotted quad is mistaken for
   a mapped one**, so `ipv6Subnet` is skipped and the client is keyed on the 32
   bits it picks itself — exactly what `ipv6Subnet` exists to prevent — landing
   in the bucket that belongs to the unrelated IPv4 client `1.2.3.4`. A client
   that can choose the low half of its address gets a fresh bucket per request,
   and can also spend a chosen IPv4 client's quota.

The same address must not produce two keys, and two unrelated addresses must not
produce one.

## The fix

Match the mapped range on the address bits, with `isMapped4()` — already
available in the declared `ip-address` floor (`^10.2.0`), so no dependency
change.

The deprecated IPv4-compatible notation (`::1.2.3.4`, RFC 4291 §2.5.5.1) keeps
its current behavior. Its range also holds `::` and `::1`, which embed no IPv4
address, so there the notation is genuinely what tells them apart. I did not use
`embeddedIPv4()`, which would additionally unwrap the NAT64 well-known prefix
(`64:ff9b::/96`): those hold a *destination* address, so unwrapping one would
hand a client another way to pick its own key.

## On the disclosure channel

`security.md` asks for vulnerabilities to be reported privately, and this line
is where GHSA-46wh-pxpv-q5gq was fixed, so I want to be explicit about why this
is a normal PR: I do not believe it is independently exploitable.

The notations that trigger it don't come out of a socket — `inet_ntop` only ever
emits a dotted quad for the mapped and compatible ranges, so `req.ip` from a
direct connection is always canonical. They can only arrive through a forwarded
header, and in any configuration where a client controls that header's text it
already controls the address outright, which is the larger problem. So what's
left is a correctness bug with hardening value, most relevant to the custom
`keyGenerator` pattern the docs recommend, where the IP passed in may come from
a CDN header. Happy to move this to a private advisory if you read the risk
differently — say the word and I'll close this.

## Verification

- `pnpm test` (lint + 244 tests) green on Node 22 and 25; `ipKeyGenerator`
  stays at 100% statement, branch, function and line coverage.
- `pnpm compile` clean.
- Added three tests: mapped addresses key identically in either notation; a
  dotted-quad-tailed IPv6 address is keyed by subnet and not into the matching
  IPv4 client's bucket; `::` and `::1` are unaffected.
- All existing assertions, including the `::1.2.3.4` ones from
  GHSA-46wh-pxpv-q5gq, pass unchanged.
- End-to-end against a `trust proxy` app with `limit: 3`: six requests from one
  /64, addressed as `2001:db8:1234:5678::0.0.0.N`, currently return six 200s
  and six distinct keys; with the patch they share one key and the fourth gets
  a 429.

Documented the mapped-address behavior in `docs/reference/helpers.mdx`, which
didn't mention it before. I left the changelog alone, since recent fixes look
like they're collected at release time — happy to add an entry if you'd prefer.
